### PR TITLE
fix(bin): on linux, resolve the potential symlink to the bash script

### DIFF
--- a/bin/eask
+++ b/bin/eask
@@ -17,5 +17,5 @@
 # Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 # Boston, MA 02110-1301, USA.
 
-BASEDIR=$(dirname "$0")
+BASEDIR=$(dirname $(readlink "$0"))
 node "$BASEDIR/../eask" "$@"


### PR DESCRIPTION
On linux, if we create a symbolic link to the binary, the $0 will
report the path in the original context (before resolving the link).
We need to resolve the link to the actual file location to compute
proper working directory for node.

This is useful when people create a symlink from ~/.local/bin/eask ->
install_dir/bin/eask instead of modifying the $PATH.