### PR TITLE
feature: Adapt `-a`/`--all` option for archives command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Fix void function `eask-source` to `eask-f-source` (#75)
 * Fix upcoming breaking changes from `package-build` (#65)
 * Add support for `elisp-lint` (#79)
+* Adapt `-a`/`--all` option for archives command (#83)
 
 ## 0.7.x
 > Released Sep 08, 2022

--- a/cmds/core/run.js
+++ b/cmds/core/run.js
@@ -64,7 +64,6 @@ function startCommand(commands, count) {
 
   let command = commands[count];
 
-  console.log('');
   console.log('[RUN]: ' + command);
   let splitted = command.split(' ');
 

--- a/lisp/core/archives.el
+++ b/lisp/core/archives.el
@@ -27,17 +27,33 @@
     (message (concat "  %-" eask--length-name "s  %-" eask--length-url "s  %-" eask--length-priority "s")
              name url (or priority 0))))
 
+(defun eask--print-archive-alist (alist)
+  "Print the archvie ALIST."
+  (let* ((names (mapcar #'car alist))
+         (eask--length-name (format "%s" (eask-seq-str-max names)))
+         (urls (mapcar #'cdr alist))
+         (eask--length-url (format "%s" (eask-seq-str-max urls)))
+         (priorities (mapcar #'cdr package-archive-priorities))
+         (eask--length-priority (format "%s" (eask-seq-str-max priorities))))
+    (mapc #'eask--print-archive alist)))
+
 (eask-start
-  (if package-archives
-      (progn
-        (let* ((names (mapcar #'car package-archives))
-               (eask--length-name (format "%s" (eask-seq-str-max names)))
-               (urls (mapcar #'cdr package-archives))
-               (eask--length-url (format "%s" (eask-seq-str-max urls)))
-               (priorities (mapcar #'cdr package-archive-priorities))
-               (eask--length-priority (format "%s" (eask-seq-str-max priorities))))
-          (mapc #'eask--print-archive package-archives))
-        (eask-info "(Total of %s archives)" (length package-archives)))
-    (eask-info "(No archive has been selected)")))
+  (cond
+   ((eask-all-p)
+    (eask-info "List all available archives:")
+    (eask-msg "")
+    (eask--print-archive-alist eask-source-mapping)
+    (eask-msg "")
+    (eask-info "(Total of %s archive%s available)" (length eask-source-mapping)
+               (eask--sinr eask-source-mapping "" "s")))
+   (package-archives
+    (eask-info "List archives that are currently using:")
+    (eask-msg "")
+    (eask--print-archive-alist package-archives)
+    (eask-msg "")
+    (eask-info "(Total of %s archive%s listed)" (length package-archives)
+               (eask--sinr package-archives "" "s")))
+   (t
+    (eask-info "(No archive has been selected)"))))
 
 ;;; core/archives.el ends here

--- a/lisp/core/run.el
+++ b/lisp/core/run.el
@@ -23,14 +23,14 @@
   "Print all available scripts."
   (eask-msg "available via `eask run-script`")
   (eask-msg "")
-  (let* ((keywords (mapcar #'car (reverse eask-scripts)))
-         (offset (eask-seq-str-max keywords))
+  (let* ((keys (mapcar #'car (reverse eask-scripts)))
+         (offset (eask-seq-str-max keys))
          (fmt (concat "  %-" (eask-2str offset) "s  %s")))
-    (dolist (keyword keywords)
-      (eask-msg fmt keyword (cdr (assoc keyword eask-scripts))))
+    (dolist (key keys)
+      (eask-msg fmt key (cdr (assoc key eask-scripts))))
     (eask-msg "")
-    (eask-info "(Total of %s available script%s)" (length keywords)
-               (eask--sinr keywords "" "s"))))
+    (eask-info "(Total of %s available script%s)" (length keys)
+               (eask--sinr keys "" "s"))))
 
 (defun eask--export-command (command)
   "Export COMMAND instruction."

--- a/test/commands/local/run.sh
+++ b/test/commands/local/run.sh
@@ -34,6 +34,7 @@ cd "./test/mini.emacs.pkg/"
 echo "Testing local commands..."
 eask info
 eask archives
+eask archives --all
 eask list --depth=0
 eask concat
 


### PR DESCRIPTION
You can now use

```
$ eask archives --all
```

to list out all archives that are available!

Example output:

```
...

List all available archives:

  gnu           https://elpa.gnu.org/packages/                    0
  nongnu        https://elpa.nongnu.org/nongnu/                   0
  celpa         https://celpa.conao3.com/packages/                0
  jcs-elpa      https://jcs-emacs.github.io/jcs-elpa/packages/    0
  marmalade     https://marmalade-repo.org/packages/              0
  melpa         https://melpa.org/packages/                       0
  melpa-stable  https://stable.melpa.org/packages/                0
  org           https://orgmode.org/elpa/                         0
  shmelpa       https://shmelpa.commandlinesystems.com/packages/  0

(Total of 9 archives available)
```