### PR TITLE
feat: Handle multiple Eask-files for `init` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Adapt `-a`/`--all` option for archives command (#83)
 * Merge command `list-all` to list with `-a`/`--all` option (#84)
 * Support JSON format with Eask-file linter (#85)
+* Handle multiple Eask-files for `init` command (#86)
 
 ## 0.7.x
 > Released Sep 08, 2022

--- a/cmds/core/init.js
+++ b/cmds/core/init.js
@@ -41,18 +41,21 @@ async function create_eask_file(dir) {
 
   let new_name = path.join(process.cwd(), 'Eask');
 
+  // Search for existing Eask-files!
   let files = fs.readdirSync(process.cwd()).filter(fn => fn.match('Eask'));
   let contine_op = false;
 
   if (files.length != 0) {
+    // Print out all existing Eask-files, and ask for continuation!
     console.log('Eask-file is already exists,');
     console.log('');
     for (let index in files) {
-      console.log('  ' + path.join(process.cwd(), files[index]));
+      console.log('   ' + path.join(process.cwd(), files[index]));
     }
     console.log('');
     await ask(`Continue the initialization? (yes) `, (answer) => { contine_op = answer; });
 
+    // Abort if declined!
     if (contine_op != '' && contine_op != 'yes') {
       process.exit(0);
     }
@@ -60,14 +63,19 @@ async function create_eask_file(dir) {
     // Ask for new name unitl the filename is available!
     let new_basename = path.basename(new_name);
     let invalid_name = false;
+
+    // Ask for new name until we found one that meets our requirements!
     while (fs.existsSync(new_name) || invalid_name) {
       let prompt;
+
+      // Handle invalid file name!
       if (invalid_name) {
         prompt = `[?] File name '${new_basename}' is invalid (should start with 'Eask'), `;
       } else {
         prompt = `[?] File name '${new_basename}' already taken, `;
       }
 
+      // Ask for new name!
       await ask(prompt + `try another one: `,
                 (answer) => {
                   new_name = path.join(process.cwd(), answer);
@@ -77,6 +85,7 @@ async function create_eask_file(dir) {
     }
   }
 
+  // Starting writing Eask-file!
   let name, version, description, entry_point, emacs_version, website_url, keywords;
   await ask(`package name: (${basename}) `, (answer) => { name = answer || basename; });
   await ask(`version: (1.0.0) `, (answer) => { version = answer || '1.0.0'; });

--- a/cmds/core/init.js
+++ b/cmds/core/init.js
@@ -58,9 +58,22 @@ async function create_eask_file(dir) {
     }
 
     // Ask for new name unitl the filename is available!
-    while (fs.existsSync(new_name)) {
-      await ask(`File name '${path.basename(new_name)}' already taken, try another one: `,
-                (answer) => { new_name = path.join(process.cwd(), answer); });
+    let new_basename = path.basename(new_name);
+    let invalid_name = false;
+    while (fs.existsSync(new_name) || invalid_name) {
+      let prompt;
+      if (invalid_name) {
+        prompt = `[?] File name '${new_basename}' is invalid (should start with 'Eask'), `;
+      } else {
+        prompt = `[?] File name '${new_basename}' already taken, `;
+      }
+
+      await ask(prompt + `try another one: `,
+                (answer) => {
+                  new_name = path.join(process.cwd(), answer);
+                  new_basename = answer;
+                  invalid_name = !answer.startsWith('Eask');
+                });
     }
   }
 


### PR DESCRIPTION
Update `init` command after #68.

Now we can create multiple Eask-file in the same directory.