### PR TITLE
feature(_prepare.el): Improve Eask-file loader to search file upward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Remove dependency `s.el` (962dd5f8d0da1443368ac2d79b0a013c153a804e)
 * Acknowledge cleaning state for `clean all` command (#87)
 * Fix keyword lint undetected (#88)
+* Improve Eask-file loader to search file upward (#89)
 
 ## 0.7.x
 > Released Sep 08, 2022

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -602,7 +602,6 @@ Eask file in the workspace."
 
 (defun eask-file-load (location &optional noerror)
   "Load Eask file in the LOCATION."
-  (jcs-print (expand-file-name location user-emacs-directory))
   (when-let* ((target-eask-file (expand-file-name location user-emacs-directory))
               (result (eask--alias-env (load target-eask-file 'noerror t))))
     (setq eask-file target-eask-file  ; assign eask file only if success
@@ -711,7 +710,7 @@ This uses function `locate-dominating-file' to look up directory tree."
                   (custom-file (locate-user-emacs-file "custom.el"))
                   (special (eask-special-p)))
              (unless special
-               (if (eask-file-try-load "../../")
+               (if (eask-file-try-load "./")
                    (eask-msg "✓ Loading Eask file in %s... done!" eask-file)
                  (eask-msg "✗ Loading Eask file... missing!")
                  (eask-help "core/init")))

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -633,8 +633,8 @@ If argument DIR is nil, we use `default-directory' instead."
               (files (cl-remove-if #'file-directory-p files)))
     (cl-remove-if-not #'eask--match-file files)))
 
-(defun eask-file-try-load (start-path)
-  "Try load eask file in START-PATH.
+(defun eask--find-files (start-path)
+  "Find the Eask-file from START-PATH.
 
 This uses function `locate-dominating-file' to look up directory tree."
   (when-let*
@@ -648,8 +648,13 @@ This uses function `locate-dominating-file' to look up directory tree."
        ;; Make `Easkfile' > `Eask' higher precedent!
        (files (sort files (lambda (item1 item2)
                             (and (string-prefix-p "Easkfile" item1)
-                                 (not (string-prefix-p "Easkfile" item2))))))
-       (file (car files)))
+                                 (not (string-prefix-p "Easkfile" item2)))))))
+    files))
+
+(defun eask-file-try-load (start-path)
+  "Try load eask file in START-PATH."
+  (when-let* ((files (eask--find-files start-path))
+              (file (car files)))
     (eask-file-load file)))
 
 (defun eask--print-env-info ()

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -623,7 +623,7 @@ Eask file in the workspace."
                             eask-full eask-major eask)))))
 
 (defun eask--all-files (&optional dir)
-  "Return a list of Eask files.
+  "Return a list of Eask files from DIR.
 
 If argument DIR is nil, we use `default-directory' instead."
   (setq dir (or dir default-directory))

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -10,6 +10,7 @@
 (require 'url-vars)
 
 (require 'cl-lib)
+(require 'files)
 (require 'ls-lisp)
 (require 'pp)
 (require 'rect)

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -627,9 +627,10 @@ Eask file in the workspace."
 
 If argument DIR is nil, we use `default-directory' instead."
   (setq dir (or dir default-directory))
-  (let* ((files (append (directory-files dir t "Easkfile[.0-9]*\\'")
-                        (directory-files dir t "Eask[.0-9]*\\'")))
-         (files (cl-remove-if #'file-directory-p files)))
+  (when-let* ((files (append
+                      (ignore-errors (directory-files dir t "Easkfile[.0-9]*\\'"))
+                      (ignore-errors (directory-files dir t "Eask[.0-9]*\\'"))))
+              (files (cl-remove-if #'file-directory-p files)))
     (cl-remove-if-not #'eask--match-file files)))
 
 (defun eask-file-try-load (start-path)

--- a/test/development/compat.el
+++ b/test/development/compat.el
@@ -23,6 +23,7 @@
     package--activate-all
     package-activate-all
     package-generate-description-file
+    locate-dominating-file
     directory-empty-p
     url-file-exists-p)
   "List of function to check Emacs compatibility.")


### PR DESCRIPTION
We not use function `locate-dominating-file` to search for valid Eask-file. This will make behaviour similar to .dir-locals.el` file.