### PR TITLE
feat: Add option `--output` to output log for Eask checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Add command to clean log files (#97)
 * Add command to clean autoloads file (#98)
 * Add command to clean pkg-file (#99)
+* feat: Add option `-o`/`--output` to output log for Eask checker (#100)
 
 ## 0.7.x
 > Released Sep 08, 2022

--- a/cmds/checker/check-eask.js
+++ b/cmds/checker/check-eask.js
@@ -27,6 +27,11 @@ exports.builder = {
     requiresArg: false,
     type: 'array',
   },
+  output: {
+    description: 'Output result to a file',
+    alias: 'o',
+    type: 'string',
+  },
   json: {
     description: 'Output lint result in JSON format',
     type: 'boolean',

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -444,7 +444,7 @@ the `eask-start' execution.")
 (defun eask-json-p ()          (eask--flag "--json"))           ; --json
 
 ;;; String (with arguments)
-(defun eask-output-p ()    (eask--flag-value "-o"))             ; --o, --output
+(defun eask-output ()      (eask--flag-value "-o"))             ; --o, --output
 (defun eask-proxy ()       (eask--flag-value "--proxy"))        ; --proxy
 (defun eask-http-proxy ()  (eask--flag-value "--http-proxy"))   ; --http-proxy
 (defun eask-https-proxy () (eask--flag-value "--https-proxy"))  ; --https-proxy

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -444,6 +444,7 @@ the `eask-start' execution.")
 (defun eask-json-p ()          (eask--flag "--json"))           ; --json
 
 ;;; String (with arguments)
+(defun eask-output-p ()    (eask--flag-value "-o"))             ; --o, --output
 (defun eask-proxy ()       (eask--flag-value "--proxy"))        ; --proxy
 (defun eask-http-proxy ()  (eask--flag-value "--http-proxy"))   ; --http-proxy
 (defun eask-https-proxy () (eask--flag-value "--https-proxy"))  ; --https-proxy
@@ -504,15 +505,16 @@ other scripts internally.  See function `eask-call'.")
      "--timestamps" "--log-level"
      "--log-file"
      "--elapsed-time"
-     "--no-color"))
+     "--no-color"
+     "--json"))
   "List of boolean type options.")
 
 (defconst eask--option-args
   (eask--form-options
-   '("--proxy" "--http-proxy" "--https-proxy" "--no-proxy"
+   '("-o"
+     "--proxy" "--http-proxy" "--https-proxy" "--no-proxy"
      "--verbose" "--silent"
-     "--depth" "--dest"
-     "--json"))
+     "--depth" "--dest"))
   "List of arguments (number/string) type options.")
 
 (defconst eask--command-list

--- a/lisp/checker/check-eask.el
+++ b/lisp/checker/check-eask.el
@@ -147,7 +147,7 @@
                     (eask--sinr checked-files "" "s"))))
 
   ;; Output file
-  (when (and content (eask-output-p))
-    (write-region content nil (eask-output-p))))
+  (when (and content (eask-output))
+    (write-region content nil (eask-output))))
 
 ;;; checker/check-eask.el ends here

--- a/src/util.js
+++ b/src/util.js
@@ -92,6 +92,7 @@ function _global_options(argv) {
   /* Number type */
   flags.push(def_flag(argv.verbose, '--verbose', argv.verbose));
   /* String type */
+  flags.push(def_flag(argv.output, '-o', argv.output));
   flags.push(def_flag(argv.proxy, '--proxy', argv.proxy));
   flags.push(def_flag(argv['http-proxy'], '--http-proxy', argv['http-proxy']));
   flags.push(def_flag(argv['https-proxy'], '--https-proxy', argv['https-proxy']));


### PR DESCRIPTION
Add option `--output` to write log to file:

```
eask check-eask -o log.txt
```