### PR TITLE
chore(package-build): Remove tar version string

### DIFF
--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -29,9 +29,6 @@
         (t               'unknown))
   "Return current OS type.")
 
-(defconst eask-tar-version-string (shell-command-to-string "tar --version")
-  "Store the `tar' version string.")
-
 (setq make-backup-files nil)
 
 (setq package-enable-at-startup  nil            ; To avoid initializing twice


### PR DESCRIPTION
Resolved after https://github.com/melpa/package-build/pull/72.

We can remove the unnecessary hassle regarding Windows tar (bsd) executable.