### PR TITLE
feat: Add capability to search through path

### DIFF
--- a/cmds/core/exec-path.js
+++ b/cmds/core/exec-path.js
@@ -19,9 +19,16 @@
 
 "use strict";
 
-exports.command = ['path', 'exec-path'];
+exports.command = ['path [patterns..]', 'exec-path [patterns..]'];
 exports.desc = 'Print the PATH (exec-path) from workspace';
+exports.builder = {
+  patterns: {
+    description: 'patterns you want to search (regex)',
+    requiresArg: false,
+    type: 'array',
+  },
+};
 
 exports.handler = async (argv) => {
-  await UTIL.e_call(argv, 'core/exec-path');
+  await UTIL.e_call(argv, 'core/exec-path', argv.patterns);
 };

--- a/cmds/core/files.js
+++ b/cmds/core/files.js
@@ -19,9 +19,16 @@
 
 "use strict";
 
-exports.command = ['files'];
-exports.desc = 'Print the list of all package files';
+exports.command = ['files [patterns..]'];
+exports.desc = 'Print all package files';
+exports.builder = {
+  patterns: {
+    description: 'patterns you want to search (wildcard)',
+    requiresArg: false,
+    type: 'array',
+  },
+};
 
 exports.handler = async (argv) => {
-  await UTIL.e_call(argv, 'core/files');
+  await UTIL.e_call(argv, 'core/files', argv.patterns);
 };

--- a/cmds/core/load-path.js
+++ b/cmds/core/load-path.js
@@ -19,9 +19,16 @@
 
 "use strict";
 
-exports.command = ['load-path'];
+exports.command = ['load-path [patterns..]'];
 exports.desc = 'Print the load-path from workspace';
+exports.builder = {
+  patterns: {
+    description: 'patterns you want to search (regex)',
+    requiresArg: false,
+    type: 'array',
+  },
+};
 
 exports.handler = async (argv) => {
-  await UTIL.e_call(argv, 'core/load-path');
+  await UTIL.e_call(argv, 'core/load-path', argv.patterns);
 };

--- a/docs/content/en/Getting Started/Basic Usage.md
+++ b/docs/content/en/Getting Started/Basic Usage.md
@@ -27,67 +27,67 @@ Eask is a command-line tool that helps you build, lint, and test Emacs Lisp pack
 Usage: eask <command> [options..]
 
 Commands:
-  archives               List out all package archives                                                                                                                                                                                              [aliases: sources]
-  autoloads              Generate autoloads file
-  clean <type>           Delete various files produced during building
-  compile [names..]      Byte compile all Emacs Lisp files in the package
-  concat [names..]       Concatenate elisp files                                                                                                                                                                                                [aliases: concatenate]
-  create <type>          Create a new elisp project
-  emacs [args..]         Execute emacs with the appropriate environment
-  eval [form]            Evaluate lisp form with a proper PATH
-  path                   Print the PATH (exec-path) from workspace                                                                                                                                                                                [aliases: exec-path]
-  exec [args..]          Execute command with correct environment PATH set up
-  files                  Print the list of all package files
-  info                   Display information about the current package
-  init                   Create new Eask file in current directory
-  install-deps           Automatically install package dependencies                                                                                                                                                           [aliases: install-dependencies, prepare]
-  install [names..]      Install packages
-  keywords               List available keywords that can be used in the header section
-  link <action>          Manage links
-  lint <type>            Run linter
-  list                   List packages
-  load-path              Print the load-path from workspace
-  load [files..]         Load elisp files
-  outdated               Show all outdated dependencies
-  package-directory      Print path to package directory
-  package [destination]  Build a package artifact, and put it into the given destination
-  pkg-file               Generate -pkg file
-  recipe                 Suggest a recipe format
-  refresh                Download package archives
-  reinstall [names..]    Reinstall packages
-  run [names..]          Run the script named [names..]                                                                                                                                                                                          [aliases: run-script]
-  search [queries..]     Search packages
-  test <type>            Run test
-  uninstall [names..]    Uninstall packages                                                                                                                                                                                                          [aliases: delete]
-  upgrade [names..]      Upgrade packages
-  check-eask [files..]   Run eask checker
-  locate                 Print out Eask installed location
-  upgrade-eask           Upgrade Eask itself                                                                                                                                                                                                   [aliases: upgrade-self]
+  archives                List out all package archives                                                                                                                                  [aliases: sources]
+  autoloads               Generate autoloads file
+  clean <type>            Delete various files produced during building
+  compile [names..]       Byte compile all Emacs Lisp files in the package
+  concat [names..]        Concatenate elisp files                                                                                                                                    [aliases: concatenate]
+  create <type>           Create a new elisp project
+  emacs [args..]          Execute emacs with the appropriate environment
+  eval [form]             Evaluate lisp form with a proper PATH
+  path [patterns..]       Print the PATH (exec-path) from workspace                                                                                                                    [aliases: exec-path]
+  exec [args..]           Execute command with correct environment PATH set up
+  files [patterns..]      Print all package files
+  info                    Display information about the current package
+  init                    Create new Eask file in current directory
+  install-deps            Automatically install package dependencies                                                                                               [aliases: install-dependencies, prepare]
+  install [names..]       Install packages
+  keywords                List available keywords that can be used in the header section
+  link <action>           Manage links
+  lint <type>             Run linter
+  list                    List packages
+  load-path [patterns..]  Print the load-path from workspace
+  load [files..]          Load elisp files
+  outdated                Show all outdated dependencies
+  package-directory       Print path to package directory
+  package [destination]   Build a package artifact, and put it into the given destination
+  pkg-file                Generate -pkg file
+  recipe                  Suggest a recipe format
+  refresh                 Download package archives
+  reinstall [names..]     Reinstall packages
+  run [names..]           Run the script named [names..]                                                                                                                              [aliases: run-script]
+  search [queries..]      Search packages
+  test <type>             Run test
+  uninstall [names..]     Uninstall packages                                                                                                                                              [aliases: delete]
+  upgrade [names..]       Upgrade packages
+  check-eask [files..]    Run eask checker
+  locate                  Print out Eask installed location
+  upgrade-eask            Upgrade Eask itself                                                                                                                                       [aliases: upgrade-self]
 
 Proxy Options:
-      --proxy        update proxy for HTTP and HTTPS to host                                                                                                                                                                                                  [string]
-      --http-proxy   update proxy for HTTP to host                                                                                                                                                                                                            [string]
-      --https-proxy  update proxy for HTTPS to host                                                                                                                                                                                                           [string]
-      --no-proxy     set no-proxy to host                                                                                                                                                                                                                     [string]
+      --proxy        update proxy for HTTP and HTTPS to host                                                                                                                                       [string]
+      --http-proxy   update proxy for HTTP to host                                                                                                                                                 [string]
+      --https-proxy  update proxy for HTTPS to host                                                                                                                                                [string]
+      --no-proxy     set no-proxy to host                                                                                                                                                          [string]
 
 Options:
-      --version             show version number                                                                                                                                                                                                              [boolean]
-      --help                show usage instructions                                                                                                                                                                                                          [boolean]
-  -g, --global              change default workspace to ~/.emacs.d/                                                                                                                                                                                          [boolean]
-  -a, --all                 enable all flag                                                                                                                                                                                                                  [boolean]
-  -q, --quick               start cleanly without loading the configuration files                                                                                                                                                                            [boolean]
-  -f, --force               enable force flag                                                                                                                                                                                                                [boolean]
-      --development, --dev  turn on development mode                                                                                                                                                                                                         [boolean]
-      --debug               turn on debug mode                                                                                                                                                                                                               [boolean]
-      --strict              report error instead of warnings                                                                                                                                                                                                 [boolean]
-      --allow-error         continue the executioon even there is error reported                                                                                                                                                                             [boolean]
-      --insecure            allow insecure connection                                                                                                                                                                                                        [boolean]
-      --timestamps          log with timestamps                                                                                                                                                                                                              [boolean]
-      --log-level           log with level                                                                                                                                                                                                                   [boolean]
-      --log-file, --lf      generate log files                                                                                                                                                                                                               [boolean]
-      --elapsed-time, --et  show elapsed time between each operation                                                                                                                                                                                         [boolean]
-      --no-color            disable color output                                                                                                                                                                                                             [boolean]
-  -v, --verbose             set verbosity from 0 to 4                                                                                                                                                                                                         [number]
+      --version             show version number                                                                                                                                                   [boolean]
+      --help                show usage instructions                                                                                                                                               [boolean]
+  -g, --global              change default workspace to ~/.emacs.d/                                                                                                                               [boolean]
+  -a, --all                 enable all flag                                                                                                                                                       [boolean]
+  -q, --quick               start cleanly without loading the configuration files                                                                                                                 [boolean]
+  -f, --force               enable force flag                                                                                                                                                     [boolean]
+      --development, --dev  turn on development mode                                                                                                                                              [boolean]
+      --debug               turn on debug mode                                                                                                                                                    [boolean]
+      --strict              report error instead of warnings                                                                                                                                      [boolean]
+      --allow-error         continue the executioon even there is error reported                                                                                                                  [boolean]
+      --insecure            allow insecure connection                                                                                                                                             [boolean]
+      --timestamps          log with timestamps                                                                                                                                                   [boolean]
+      --log-level           log with level                                                                                                                                                        [boolean]
+      --log-file, --lf      generate log files                                                                                                                                                    [boolean]
+      --elapsed-time, --et  show elapsed time between each operation                                                                                                                              [boolean]
+      --no-color            disable color output                                                                                                                                                  [boolean]
+  -v, --verbose             set verbosity from 0 to 4                                                                                                                                              [number]
 
 For more information, find the manual at https://emacs-eask.github.io/
 ```

--- a/docs/content/en/Getting Started/Commands and options.md
+++ b/docs/content/en/Getting Started/Commands and options.md
@@ -184,24 +184,30 @@ Print the `PATH` environment variable of this project.
 Alias: `exec-path`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] path
+$ eask [GLOBAL-OPTIONS] path [PATTERNS..]
 ```
+
+Optionally, you can pass in `[PATTERNS..]` to perform the search.
 
 ## 🔍 eask load-path
 
 Print the load path containing the dependencies of the current project.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] load-path
+$ eask [GLOBAL-OPTIONS] load-path [PATTERNS..]
 ```
+
+Optionally, you can pass in `[PATTERNS..]` to perform the search. 
 
 ## 🔍 eask files
 
 Print the list of all package files.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] files
+$ eask [GLOBAL-OPTIONS] files [PATTERNS..]
 ```
+
+If `[PATTERNS..]` are defined, it will display files that match that pattern.
 
 ## 🔍 eask exec
 

--- a/lisp/core/exec-path.el
+++ b/lisp/core/exec-path.el
@@ -14,14 +14,23 @@
        (file-name-directory (nth 1 (member "-scriptload" command-line-args))))
       nil t)
 
+(eask-load "core/load-path")
+
 (defun eask--print-exec-path (path)
   "Print out the PATH."
   (message "%s" path))
 
 (eask-start
   (eask-pkg-init)
-  (mapc #'eask--print-exec-path exec-path)
-  (eask-msg "")
-  (eask-info "(Total of %s exec-path)" (length exec-path)))
+  (let* ((patterns (eask-args))
+         (exec-path (if patterns
+                        (cl-remove-if-not #'eask--filter-path exec-path)
+                      exec-path)))
+    (eask-msg "")
+    (mapc #'eask--print-exec-path exec-path)
+    (if (zerop (length exec-path))
+        (eask-info "(No exec-path found)")
+      (eask-msg "")
+      (eask-info "(Total of %s exec-path)" (length exec-path)))))
 
 ;;; core/exec-path.el ends here

--- a/lisp/core/exec.el
+++ b/lisp/core/exec.el
@@ -1,4 +1,4 @@
-;;; core/exec.el --- Execute command with correct load-path set up  -*- lexical-binding: t; -*-
+;;; core/exec.el --- Execute command with correct PATH set up  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;;
@@ -9,7 +9,7 @@
 ;;
 ;;  Initialization options:
 ;;
-;;    [args..]     execute command with correct load-path set up
+;;    [args..]     execute command with correct PATH set up
 ;;
 
 ;;; Code:

--- a/lisp/core/files.el
+++ b/lisp/core/files.el
@@ -19,7 +19,9 @@
   (message "%s" filename))
 
 (eask-start
-  (let ((files (eask-package-files)))
+  (let* ((patterns (eask-args))
+         (eask-files (or patterns eask-files))
+         (files (eask-package-files)))
     (mapc #'eask--print-filename files)
     (eask-msg "")
     (eask-info "(Total of %s item%s listed)" (length files) (eask--sinr files "" "s"))))

--- a/lisp/core/files.el
+++ b/lisp/core/files.el
@@ -20,10 +20,13 @@
 
 (eask-start
   (let* ((patterns (eask-args))
-         (eask-files (or patterns eask-files))
-         (files (eask-package-files)))
+         (files (if patterns
+                    (eask-expand-file-specs patterns)
+                  (eask-package-files))))
     (mapc #'eask--print-filename files)
-    (eask-msg "")
-    (eask-info "(Total of %s item%s listed)" (length files) (eask--sinr files "" "s"))))
+    (if (zerop (length files))
+        (eask-info "(No package files found)")
+      (eask-msg "")
+      (eask-info "(Total of %s item%s listed)" (length files) (eask--sinr files "" "s")))))
 
 ;;; core/files.el ends here

--- a/lisp/core/load-path.el
+++ b/lisp/core/load-path.el
@@ -18,10 +18,23 @@
   "Print out the PATH."
   (message "%s" path))
 
+(defun eask--filter-path (path)
+  "Filter the PATH out by search regex."
+  (cl-some (lambda (regex)
+             (string-match-p regex path))
+           (eask-args)))
+
 (eask-start
   (eask-pkg-init)
-  (mapc #'eask--print-load-path load-path)
-  (eask-msg "")
-  (eask-info "(Total of %s load-path)" (length load-path)))
+  (let* ((patterns (eask-args))
+         (load-path (if patterns
+                        (cl-remove-if-not #'eask--filter-path load-path)
+                      load-path)))
+    (eask-msg "")
+    (mapc #'eask--print-load-path load-path)
+    (if (zerop (length load-path))
+        (eask-info "(No load-path found)")
+      (eask-msg "")
+      (eask-info "(Total of %s load-path)" (length load-path)))))
 
 ;;; core/load-path.el ends here

--- a/test/commands/local/run.sh
+++ b/test/commands/local/run.sh
@@ -38,6 +38,12 @@ eask archives --all
 eask list --depth=0
 eask concat
 
+# PATH environment
+eask path
+eask path      bin
+eask load-path
+eask load-path bin
+
 # Preparation
 eask prepare --dev
 eask package


### PR DESCRIPTION
New behavior for these commands:

- `eask files`
- `eask path` or `eask exec-path`
- `eask load-path`

You can now pass in `[PATTERN..]` to perform the search.

```
$ eask files *.el
```