### PR TITLE
feat(link/add): Don't link when no -pkg.el file

### DIFF
--- a/lisp/help/link/add/error
+++ b/lisp/help/link/add/error
@@ -1,0 +1,7 @@
+
+💡 You need the `-pkg.el` file so the `package.el` can recognize your package.
+   
+Options are,
+   
+  - [ ] Use `eask pkg-file` to create one
+  - [ ] Write your own `-pkg.el` file

--- a/lisp/help/link/add/success
+++ b/lisp/help/link/add/success
@@ -1,12 +1,10 @@
 
 ✓ You have now created the link, here are things you might want to consider:
   
-  - [ ] `SOURCE-pkg.el` file                                  Package descriptor
   - [ ] (Optional) `SOURCE-autoloads.el`                      Package autoloads
   - [ ] (Optional) Compile source package with `.elc` files   Use `.elc` may be metter choice
 
 If the source package uses Eask, you can use `eask` commands to accomplish these tasks.
    
-  * `eask pkg-file`
   * `eask autoloads`
   * `eask compile`

--- a/lisp/link/add.el
+++ b/lisp/link/add.el
@@ -61,8 +61,7 @@
      ;; Create the link
      (t
       (let ((links (eask--links))
-            (pkg-el   (expand-file-name (package--description-file source) source))
-            (pkg-eask (car (eask--all-files source)))
+            (pkg-el (expand-file-name (package--description-file name) source))
             (pkg-desc))
         (cond
          ((ignore-errors (file-exists-p pkg-el))
@@ -76,23 +75,13 @@
                 eask--link-package-version (package-version-join
                                             (package-desc-version pkg-desc)))
           ;; XXX: Install dependencies for linked package
-          (eask--install-packages (eask--package-desc-reqs pkg-desc)))
-         ((ignore-errors (file-exists-p pkg-eask))
-          (let ((deps))
-            (eask--save-load-eask-file pkg-eask
-                (progn
-                  (setq eask--link-package-name (eask-package-name)
-                        eask--link-package-version (eask-package-version))
-                  (setq deps eask-depends-on))
-              (eask-error "✗ Error loading Eask-file: %s" pkg-eask))
-            ;; XXX: Install dependencies for linked package
-            (eask-install-dependencies)))
+          (eask--install-packages (eask--package-desc-reqs pkg-desc))
+          (eask--create-link name source)
+          (when (and (zerop (length links))         ; if no link previously,
+                     (= 1 (length (eask--links))))  ; and first link created!
+            (eask-help "link/add/success")))
          (t
-          (eask-error "✗ Link source %s doesn't have an Eask or %s-pkg.el file"
-                      source name)))
-        (eask--create-link name source)
-        (when (and (zerop (length links))         ; if no link previously,
-                   (= 1 (length (eask--links))))  ; and first link created!
-          (eask-help "link/add")))))))
+          (eask-info "✗ (Missing `%s-pkg.el` file in your source folder)" name)
+          (eask-help "link/add/error"))))))))
 
 ;;; link/add.el ends here

--- a/lisp/link/add.el
+++ b/lisp/link/add.el
@@ -38,9 +38,9 @@
          (link-path (expand-file-name dir-name package-user-dir)))
     (when (file-exists-p link-path)
       (eask-with-progress
-        "!! The link already present; override the existing link... "
+        (ansi-yellow "!! The link already present; override the existing link... ")
         (eask--delete-symlink link-path)
-        "done ✓"))
+        (ansi-yellow "done ✓")))
     (make-symbolic-link source link-path)
     (eask-msg "")
     (eask-info "✓ Created link from %s to %s" source (eask-f-filename link-path))))


### PR DESCRIPTION
For #131.

Edit: Drop Eask-file as an option since we would eventually need a `-pkg.el` file.