### PR TITLE
feat(cask): Add option to convert Cask to Eask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Allow linter list through all errors (#134 and #137)
 * Omit `nil` value for conditions in `development` scope (#143 and #144)
 * Move `pkg-file` and `autoloads` commands under `generate` subcommand (#142)
+* Add option to convert Cask to Eask (#141 and #145)
 
 ## 0.7.x
 > Released Sep 08, 2022

--- a/cmds/core/init.js
+++ b/cmds/core/init.js
@@ -23,14 +23,39 @@ const path = require('path');
 const fs = require('fs');
 const readline = require('readline');
 
-var instance;  /* `readline` instance */
-
-exports.command = ['init'];
-exports.desc = 'Create new Eask file in current directory';
-
-exports.handler = async ({}) => {
-  await create_eask_file();
+exports.command = ['init [files..]'];
+exports.desc = 'Initialize project to use Eask';
+exports.builder = {
+  from: {
+    description: 'build from an existing package',
+    requiresArg: true,
+    type: 'string',
+  },
+  files: {
+    description: 'files to use with `from` flag',
+    requiresArg: false,
+    type: 'array',
+  },
 };
+
+exports.handler = async (argv) => {
+  if (argv.from) {
+    switch (argv.from) {
+    case 'cask':
+      await UTIL.e_call(argv, 'init/cask'
+                        , UTIL.def_flag(argv.from, '--from', argv.from)
+                        , argv.files);
+      break;
+    default:
+      console.log(`Invalid argument, from: ${argv.from}`);
+      break;
+    }
+  } else {
+    await create_eask_file();
+  }
+};
+
+var instance;  /* `readline` instance */
 
 async function create_eask_file(dir) {
   let basename = path.basename(process.cwd());

--- a/docs/content/en/Getting Started/Basic Usage.md
+++ b/docs/content/en/Getting Started/Basic Usage.md
@@ -37,9 +37,9 @@ Commands:
   path [patterns..]       Print the PATH (exec-path) from workspace                                                                                                                          [aliases: exec-path]
   exec [args..]           Execute command with correct environment PATH set up
   files [patterns..]      Print all package files
-  generate <type>         Generate files use for development
+  generate <type>         Generate files that are used for the development
   info                    Display information about the current package
-  init                    Create new Eask file in current directory
+  init [files..]          Initialize project to use Eask
   install-deps            Automatically install package dependencies                                                                                                     [aliases: install-dependencies, prepare]
   install [names..]       Install packages
   keywords                List available keywords that can be used in the header section

--- a/docs/content/en/Getting Started/Commands and options.md
+++ b/docs/content/en/Getting Started/Commands and options.md
@@ -35,7 +35,7 @@ Often use commands that are uncategorized.
 
 ## 🔍 eask init
 
-Eask will generate file like:
+Eask will generate the file like this:
 
 ```elisp
 (package "PACKAGE-NAME"

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -75,7 +75,7 @@ will return `lint-checkdoc' with a dash between two subcommands."
 
 (defun eask-special-p ()
   "Return t if the command that can be run without Eask-file existence."
-  (member (eask-command) '("keywords")))
+  (member (eask-command) '("init-cask" "keywords")))
 
 (defun eask-checker-p ()
   "Return t if running Eask as the checker."
@@ -454,6 +454,7 @@ the `eask-start' execution.")
 (defun eask-no-proxy ()    (eask--flag-value "--no-proxy"))     ; --no-proxy
 (defun eask-destination () (eask--flag-value "--dest"))         ; --dest, --destination
 (defalias 'eask-dest #'eask-destination)
+(defun eask-from ()        (eask--flag-value "--from"))         ; --from
 
 ;;; Number (with arguments)
 (defun eask-depth () (eask--str2num (eask--flag-value "--depth")))       ; --depth
@@ -517,7 +518,8 @@ other scripts internally.  See function `eask-call'.")
    '("--output"
      "--proxy" "--http-proxy" "--https-proxy" "--no-proxy"
      "--verbose" "--silent"
-     "--depth" "--dest"))
+     "--depth" "--dest"
+     "--from"))
   "List of arguments (number/string) type options.")
 
 (defconst eask--command-list
@@ -604,7 +606,8 @@ Eask file in the workspace."
 
 (defun eask-root-del (filename)
   "Remove Eask file root path from FILENAME."
-  (when (stringp filename) (eask-s-replace eask-file-root "" filename)))
+  (when (stringp filename)
+    (eask-s-replace (or eask-file-root default-directory) "" filename)))
 
 (defun eask-file-load (location &optional noerror)
   "Load Eask file in the LOCATION."

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -1279,15 +1279,29 @@ Standard is, 0 (error), 1 (warning), 2 (info), 3 (log), 4 or above (debug)."
 ;;
 ;;; Help
 
+(defun eask--help-display ()
+  "Display help instruction."
+  (goto-char (point-min))
+  (let ((max-column 0))
+    (while (not (eobp))
+      (forward-line 1)
+      (goto-char (line-beginning-position))
+      (insert "  ")
+      (goto-char (line-end-position))
+      (setq max-column (max (current-column) max-column)))
+    (eask-msg (concat "''" (spaces-string max-column) "''"))
+    (eask-msg (ansi-white (buffer-string)))
+    (eask-msg (concat "''" (spaces-string max-column) "'" "'"))))
+
 (defun eask-help (command)
-  "Show help."
+  "Show COMMAND's help instruction."
   (let* ((command (eask-2str command))  ; convert to string
          (help-file (concat eask-lisp-root "help/" command)))
     (if (file-exists-p help-file)
         (with-temp-buffer
           (insert-file-contents help-file)
           (unless (string= (buffer-string) "")
-            (eask-msg (ansi-white (buffer-string)))))
+            (eask--help-display)))
       (eask-error "Help manual missig %s" help-file))))
 
 ;;

--- a/lisp/help/init/cask
+++ b/lisp/help/init/cask
@@ -1,0 +1,6 @@
+
+💡 Make sure you have a valid Cask-file in your directory
+
+💡 Or specify Cask-file explicitly, like:
+
+    $ eask init --from=cask /path/to/Cask

--- a/lisp/init/cask.el
+++ b/lisp/init/cask.el
@@ -22,7 +22,7 @@
          (new-filename (expand-file-name new-file))
          (converted))
     (eask-with-progress
-      (format "Converting file %s to %s... " file new-file)
+      (format "Converting file `%s` to `%s`... " file new-file)
       (eask-with-verbosity 'debug
         (cond ((not (string-prefix-p "Cask" file))
                (eask-debug "✗ Invalid Cask filename, the file should start with `Cask`"))
@@ -43,7 +43,7 @@
   (let* ((patterns (eask-args))
          (files (if patterns
                     (eask-expand-file-specs patterns)
-                  (directory-files default-directory t "/Cask\\'")))
+                  (directory-files default-directory t "Cask")))
          (converted 0))
     (cond
      ;; Files found, do the action!
@@ -56,12 +56,10 @@
                  (eask--sinr converted "" "s")))
      ;; Pattern defined, but no file found!
      (patterns
-      (eask-msg "")
-      (eask-info "No files found with wildcard pattern: %s"
+      (eask-info "(No files found with wildcard pattern: %s)"
                  (mapconcat #'identity patterns " ")))
      ;; Default, print help!
      (t
-      (eask-msg "")
       (eask-info "(No Cask-files have been converted to Eask)")
       (eask-help "init/cask")))))
 

--- a/lisp/init/cask.el
+++ b/lisp/init/cask.el
@@ -56,7 +56,7 @@
                  (eask--sinr converted "" "s")))
      ;; Pattern defined, but no file found!
      (patterns
-      (eask-info "(No files found with wildcard pattern: %s)"
+      (eask-info "No files found with wildcard pattern: %s"
                  (mapconcat #'identity patterns " ")))
      ;; Default, print help!
      (t

--- a/lisp/init/cask.el
+++ b/lisp/init/cask.el
@@ -1,0 +1,68 @@
+;;; init/cask.el --- Initialize Eask from Cask  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;;
+;; Commmand use to convert Cask-file to Eask-file
+;;
+;;   $ eask init --from cask
+;;
+
+;;; Code:
+
+(load (expand-file-name
+       "../_prepare.el"
+       (file-name-directory (nth 1 (member "-scriptload" command-line-args))))
+      nil t)
+
+(defun eask--convert-cask (filename)
+  "Convert Cask FILENAME to Eask."
+  (let* ((filename (expand-file-name filename))
+         (file (eask-root-del filename))
+         (new-file (eask-s-replace "Cask" "Eask" file))
+         (new-filename (expand-file-name new-file))
+         (converted))
+    (eask-with-progress
+      (format "Converting file %s to %s... " file new-file)
+      (eask-with-verbosity 'debug
+        (cond ((not (string-prefix-p "Cask" file))
+               (eask-debug "✗ Invalid Cask filename, the file should start with `Cask`"))
+              ((file-exists-p new-filename)
+               (eask-debug "✗ The file `%s` already presented" new-file))
+              (t
+               (with-current-buffer (find-file new-filename)
+                 (insert-file-contents file)
+                 (goto-char (point-min))
+                 (while (re-search-forward "(source " nil t)
+                   (insert "'"))  ; make it symbol
+                 (save-buffer))
+               (setq converted t))))
+      (if converted "done ✓" "skipped ✗"))
+    converted))
+
+(eask-start
+  (let* ((patterns (eask-args))
+         (files (if patterns
+                    (eask-expand-file-specs patterns)
+                  (directory-files default-directory t "/Cask\\'")))
+         (converted 0))
+    (cond
+     ;; Files found, do the action!
+     (files
+      (dolist (file files)
+        (when (eask--convert-cask file)
+          (cl-incf converted)))
+      (eask-msg "")
+      (eask-info "(Total of %s Cask-file%s converted)" converted
+                 (eask--sinr converted "" "s")))
+     ;; Pattern defined, but no file found!
+     (patterns
+      (eask-msg "")
+      (eask-info "No files found with wildcard pattern: %s"
+                 (mapconcat #'identity patterns " ")))
+     ;; Default, print help!
+     (t
+      (eask-msg "")
+      (eask-info "(No Cask-files have been converted to Eask)")
+      (eask-help "init/cask")))))
+
+;;; init/cask.el ends here

--- a/lisp/lint/checkdoc.el
+++ b/lisp/lint/checkdoc.el
@@ -71,7 +71,6 @@
                  (mapconcat #'identity patterns " ")))
      ;; Default, print help!
      (t
-      (eask-msg "")
       (eask-info "(No files have been checked (checkdoc))")
       (eask-help "lint/checkdoc")))))
 

--- a/lisp/lint/declare.el
+++ b/lisp/lint/declare.el
@@ -52,7 +52,6 @@
                  (mapconcat #'identity patterns " ")))
      ;; Default, print help!
      (t
-      (eask-msg "")
       (eask-info "(No files have been checked (declare))")
       (eask-help "lint/declare")))))
 

--- a/lisp/lint/indent.el
+++ b/lisp/lint/indent.el
@@ -65,7 +65,6 @@
                  (mapconcat #'identity patterns " ")))
      ;; Default, print help!
      (t
-      (eask-msg "")
       (eask-info "(No files have been linted)")
       (eask-help "lint/indent")))))
 


### PR DESCRIPTION
For #141. Add the options,

```
$ eask init --from cask [files..]
```

Another feature, the help instruction now look like this:

```
''                                                           ''

    Make sure you have a valid Cask-file in your directory

    Or specify Cask-file explicitly, like:

      $ eask init --from=cask /path/to/Cask

''                                                           ''
```

Expect for improvements.