### PR TITLE
fix(init): compare only the basename instead of entire path

### DIFF
--- a/lisp/init/cask.el
+++ b/lisp/init/cask.el
@@ -24,7 +24,7 @@
     (eask-with-progress
       (format "Converting file `%s` to `%s`... " file new-file)
       (eask-with-verbosity 'debug
-        (cond ((not (string-prefix-p "Cask" file))
+        (cond ((not (string-prefix-p "Cask" (file-name-nondirectory file)))
                (eask-debug "✗ Invalid Cask filename, the file should start with `Cask`"))
               ((file-exists-p new-filename)
                (eask-debug "✗ The file `%s` already presented" new-file))


### PR DESCRIPTION
On linux, file contains the absolute path to the file which will rarely if ever start with "Cask".

![image](https://user-images.githubusercontent.com/2664959/223260340-83551ebb-a54e-4952-a7fa-8bffdde63029.png)