### PR TITLE
feat: Use standard output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Split up `config` and `global` space into two different environments (#167)
 * Add use of `--show-hidden` option (#168)
 * Add command to generate `ignore` file (#169)
+* Use standard output (#170)
 
 ## 0.8.x
 > Released Mar 08, 2023

--- a/cmds/core/status.js
+++ b/cmds/core/status.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2023 Jen-Chieh Shen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Emacs; see the file COPYING.  If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+"use strict";
+
+exports.command = ['status'];
+exports.desc = 'Display the state of the workspace';
+
+exports.handler = async (argv) => {
+  await UTIL.e_call(argv, 'core/status');
+};

--- a/docs/content/en/Getting Started/Basic Usage.md
+++ b/docs/content/en/Getting Started/Basic Usage.md
@@ -60,6 +60,7 @@ Commands:
   reinstall [names..]     Reinstall packages
   run [names..]           Run the script named [names..]                                                                                                                                    [aliases: run-script]
   search [queries..]      Search packages
+  status                  Display the state of the workspace
   test <type>             Run test
   uninstall [names..]     Uninstall packages                                                                                                                                                    [aliases: delete]
   upgrade [names..]       Upgrade packages
@@ -86,7 +87,7 @@ Options:
       --strict       report error instead of warnings                                                                                                                                                   [boolean]
       --allow-error  continue the executioon even there is error reported                                                                                                                               [boolean]
       --insecure     allow insecure connection                                                                                                                                                          [boolean]
-  -v, --verbose      set verbosity from 0 to 4                                                                                                                                                           [number]
+  -v, --verbose      set verbosity from 0 to 5                                                                                                                                                           [number]
 
 For more information, find the manual at https://emacs-eask.github.io/
 ```

--- a/docs/content/en/Getting Started/Commands and options.md
+++ b/docs/content/en/Getting Started/Commands and options.md
@@ -66,6 +66,14 @@ Show information about the project or configuration.
 $ eask [GLOBAL-OPTIONS] info
 ```
 
+## 🔍 eask status
+
+Display the state of the workspace.
+
+```sh
+$ eask [GLOBAL-OPTIONS] status
+```
+
 ## 🔍 eask install-deps
 
 To install all dependencies.

--- a/eask
+++ b/eask
@@ -96,7 +96,7 @@ yargs
       hidden: true,
     },
     'verbose': {
-      description: `set verbosity from 0 to 4`,
+      description: `set verbosity from 0 to 5`,
       alias: 'v',
       requiresArg: true,
       type: 'number',

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -726,20 +726,6 @@ This uses function `locate-dominating-file' to look up directory tree."
               (file (car files)))
     (eask-file-load file)))
 
-(defun eask--print-env-info ()
-  "Display environment information at the very top of the execution."
-  (eask-msg "")
-  (eask-msg "✓ Checking Emacs version %s... done!" emacs-version)
-  (eask-with-verbosity 'debug
-    (eask-msg "  💡 Invoke from %s" invocation-directory)
-    (eask-msg "  💡 Build No. %s" emacs-build-number)
-    (eask-msg "  💡 System configuration %s" system-configuration)
-    (when-let ((emacs-build-time)
-               (time (format-time-string "%Y-%m-%d" emacs-build-time)))
-      (eask-msg "  💡 Build time %s" time)))
-  (eask-msg "✓ Checking system %s... done!" system-type))
-
-
 (defmacro eask--with-hooks (&rest body)
   "Execute BODY with before/after hooks."
   (declare (indent 0) (debug t))
@@ -769,17 +755,17 @@ This uses function `locate-dominating-file' to look up directory tree."
        (setq eask--initialized-p t)
        (eask--setup-env
          (eask--handle-global-options)
-         (eask--print-env-info)
          (cond
           ((or (eask-global-p) (eask-special-p))  ; Commands without Eask-file needed
            (eask--setup-home (concat eask-homedir "../")  ; `/home/user/', escape `.eask'
              (let ((eask--first-init-p (not (file-directory-p user-emacs-directory))))
                ;; We accept Eask-file in `global' scope, but it shouldn't be used
                ;; for the sandbox.
-               (if (eask-file-try-load "./")
-                   (eask-msg "✓ Loading global Eask file in %s... done!" eask-file)
-                 (eask-msg "✗ Loading global Eask file... missing!"))
-               (message "")
+               (eask-with-verbosity 'debug
+                 (if (eask-file-try-load "./")
+                     (eask-msg "✓ Loading global Eask file in %s... done!" eask-file)
+                   (eask-msg "✗ Loading global Eask file... missing!"))
+                 (message ""))
                (package-activate-all)
                (ignore-errors (make-directory package-user-dir t))
                (eask--with-hooks ,@body))))
@@ -787,14 +773,15 @@ This uses function `locate-dominating-file' to look up directory tree."
            (let ((inhibit-config (eask-quick-p)))
              ;; We accept Eask-file in `config' scope, but it shouldn't be used
              ;; for the sandbox.
-             (if (eask-file-try-load "./")
-                 (eask-msg "✓ Loading config Eask file in %s... done!" eask-file)
-               (eask-msg "✗ Loading config Eask file... missing!"))
-             (message "")
+             (eask-with-verbosity 'debug
+               (if (eask-file-try-load "./")
+                   (eask-msg "✓ Loading config Eask file in %s... done!" eask-file)
+                 (eask-msg "✗ Loading config Eask file... missing!"))
+               (message ""))
              (package-activate-all)
              (eask-with-progress
                (ansi-green "Loading your configuration... ")
-               (eask-with-verbosity 'debug
+               (eask-with-verbosity 'all
                  (unless inhibit-config
                    (load (locate-user-emacs-file "early-init.el") t)
                    (load (locate-user-emacs-file "../.emacs") t)
@@ -804,12 +791,13 @@ This uses function `locate-dominating-file' to look up directory tree."
           (t
            (eask--setup-home nil  ; `nil' is the `default-directory'
              (let ((eask--first-init-p (not (file-directory-p user-emacs-directory))))
-               (if (eask-file-try-load "./")
-                   (eask-msg "✓ Loading Eask file in %s... done!" eask-file)
-                 (eask-msg "✗ Loading Eask file... missing!")
-                 (eask-help "core/init"))
-               (when eask-file
-                 (message "")
+               (eask-with-verbosity 'debug
+                 (if (eask-file-try-load "./")
+                     (eask-msg "✓ Loading Eask file in %s... done!" eask-file)
+                   (eask-msg "✗ Loading Eask file... missing!"))
+                 (message ""))
+               (if (not eask-file)
+                   (eask-help "core/init")
                  (package-activate-all)
                  (ignore-errors (make-directory package-user-dir t))
                  (eask--silent (eask-setup-paths))
@@ -1129,7 +1117,7 @@ This uses function `locate-dominating-file' to look up directory tree."
 (defcustom eask-verbosity 3
   "Log level for all messages; 4 means trace most anything, 0 means nothing.
 
-Standard is, 0 (error), 1 (warning), 2 (info), 3 (log), 4 or above (debug)."
+Standard is, 0 (error), 1 (warning), 2 (info), 3 (log), 4 (debug), 5 (all)."
   :type 'integer)
 
 (defcustom eask-timestamps nil
@@ -1141,7 +1129,8 @@ Standard is, 0 (error), 1 (warning), 2 (info), 3 (log), 4 or above (debug)."
   :type 'boolean)
 
 (defcustom eask-level-color
-  '((debug . ansi-blue)
+  '((all   . ansi-magenta)
+    (debug . ansi-blue)
     (log   . ansi-white)
     (info  . ansi-cyan)
     (warn  . ansi-yellow)
@@ -1152,6 +1141,7 @@ Standard is, 0 (error), 1 (warning), 2 (info), 3 (log), 4 or above (debug)."
 (defun eask--verb2lvl (symbol)
   "Convert verbosity SYMBOL to level."
   (cl-case symbol
+    (`all   5)
     (`debug 4)
     (`log   3)
     (`info  2)

--- a/lisp/core/emacs.el
+++ b/lisp/core/emacs.el
@@ -23,7 +23,6 @@
 ;;; Below is copied from `eask-start' macro
 
 (eask--handle-global-options)
-(eask--print-env-info)
 
 (setq user-emacs-directory (expand-file-name (concat ".eask/" emacs-version "/"))
       package-user-dir (expand-file-name "elpa" user-emacs-directory)

--- a/lisp/core/status.el
+++ b/lisp/core/status.el
@@ -1,0 +1,31 @@
+;;; core/status.el --- Display the state of the workspace  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;;
+;; Display the state of the workspace
+;;
+;;   $ eask status
+;;
+
+;;; Code:
+
+(let ((dir (file-name-directory (nth 1 (member "-scriptload" command-line-args)))))
+  (load (expand-file-name "_prepare.el"
+                          (locate-dominating-file dir "_prepare.el"))
+        nil t))
+
+(eask-start
+  (eask-msg "✓ Checking Emacs version %s... done!" emacs-version)
+  (eask-with-verbosity 'debug
+    (eask-msg "  💡 Invoke from %s" invocation-directory)
+    (eask-msg "  💡 Build No. %s" emacs-build-number)
+    (eask-msg "  💡 System configuration %s" system-configuration)
+    (when-let ((emacs-build-time)
+               (time (format-time-string "%Y-%m-%d" emacs-build-time)))
+      (eask-msg "  💡 Build time %s" time)))
+  (eask-msg "✓ Checking system %s... done!" system-type)
+  (if eask-file
+      (eask-msg "✓ Eask file in %s... done!" eask-file)
+    (eask-msg "✗ Eask file... missing!")))
+
+;;; core/status.el ends here

--- a/lisp/core/status.el
+++ b/lisp/core/status.el
@@ -15,7 +15,7 @@
         nil t))
 
 (eask-start
-  (eask-msg "✓ Checking Emacs version %s... done!" emacs-version)
+  (eask-msg "✓ Emacs version %s" emacs-version)
   (eask-with-verbosity 'debug
     (eask-msg "  💡 Invoke from %s" invocation-directory)
     (eask-msg "  💡 Build No. %s" emacs-build-number)
@@ -23,9 +23,17 @@
     (when-let ((emacs-build-time)
                (time (format-time-string "%Y-%m-%d" emacs-build-time)))
       (eask-msg "  💡 Build time %s" time)))
-  (eask-msg "✓ Checking system %s... done!" system-type)
+  (eask-msg "✓ System type %s" system-type)
+  (eask-msg "✓ Emacs directory %s" user-emacs-directory)
+  (eask-with-verbosity 'debug
+    (eask-msg "  💡 ELPA directory %s" package-user-dir))
   (if eask-file
-      (eask-msg "✓ Eask file in %s... done!" eask-file)
-    (eask-msg "✗ Eask file... missing!")))
+      (eask-msg "✓ Eask file in %s" eask-file)
+    (eask-msg "✗ Eask file... missing!"))
+
+  (eask-msg "")
+  (eask-info "(Total of %s states listed)" (if (eask--reach-verbosity-p 'debug)
+                                               9
+                                             4)))
 
 ;;; core/status.el ends here

--- a/src/util.js
+++ b/src/util.js
@@ -179,12 +179,12 @@ async function e_call(argv, script, ...args) {
     console.log(`Running Eask in the ${env_status} environment`);
     console.log('Press Ctrl+C to cancel.');
     console.log('');
-    if (argv.verbose >= 4) {
+    if (4 <= argv.verbose) {  // `debug` scope
       console.log('Executing script inside Emacs...');
       console.log('');
     }
-    if (argv.verbose >= 5) {
-      console.log('[DEBUG] emacs ' + cmd.join(' '));
+    if (5 <= argv.verbose) {  // `all` scope
+      console.log('[EXEC] emacs ' + cmd.join(' '));
       console.log('');
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -179,9 +179,14 @@ async function e_call(argv, script, ...args) {
     console.log(`Running Eask in the ${env_status} environment`);
     console.log('Press Ctrl+C to cancel.');
     console.log('');
-    console.log('Executing script inside Emacs...');
-    if (argv.verbose == 4)
+    if (argv.verbose >= 4) {
+      console.log('Executing script inside Emacs...');
+      console.log('');
+    }
+    if (argv.verbose >= 5) {
       console.log('[DEBUG] emacs ' + cmd.join(' '));
+      console.log('');
+    }
 
     setup_env();
     let proc = child_process.spawn(cli_args(cmd), { stdio: 'inherit', shell: true });

--- a/test/commands/local/run.sh
+++ b/test/commands/local/run.sh
@@ -33,6 +33,7 @@ cd "./test/fixtures/mini.emacs.pkg.1/"
 
 echo "Testing local commands..."
 eask info
+eask status
 eask archives
 eask archives --all
 eask list --depth=0


### PR DESCRIPTION
For #123.

Move the header information to a command `eask status`.