### PR TITLE
feat: Use environment PATH to specify Emacs version to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Add command to generate `ignore` file (#169)
 * Use standard output (#170)
 * Fix non-displayable character, use ascii instead (#172)
+* Use environment PATH to specify Emacs version to use (#173)
 
 ## 0.8.x
 > Released Mar 08, 2023

--- a/cmds/core/emacs.js
+++ b/cmds/core/emacs.js
@@ -35,7 +35,7 @@ exports.builder = async (yargs) => {
 exports.handler = async (argv) => {
   let _path = UTIL.el_script('core/emacs');
 
-  let default_cmd = ['emacs', '-Q', '-l', _path];
+  let default_cmd = [EASK_EMACS, '-Q', '-l', _path];
   let rest = process.argv.slice(3);
   let cmd = default_cmd.concat(rest);
 

--- a/docs/content/en/Getting Started/Finding Emacs.md
+++ b/docs/content/en/Getting Started/Finding Emacs.md
@@ -3,7 +3,23 @@ title: 🔭 Finding Emacs
 weight: 150
 ---
 
-By default, Eask will use whatever the Emacs version exists in your environment
-path. Use **emacs --version** to check your Emacs version.
+By default, packages are installed for the default Emacs, i.e., the one behind
+the `emacs` command. To pick a different Emacs, set the environment variable
+`EMACS` to the command name or executable path of the Emacs to use:
 
-There is currently no way to specify an Emacs version to execute.
+```sh
+$ EMACS="emacs24.1" eask command
+```
+
+Note that installed dependencies are scoped on the version of Emacs. So when
+switching between versions you will have to install the dependencies for each:
+
+```sh
+$ EMACS="emacs24.5" eask install
+```
+
+There are, unfortunately, circumstances under which Emacs itself resets the
+`EMACS` variable in a way which conflicts with **eask**, in which case you can
+use the environment variable `EASK_EMACS` instead. Specifically, this problem
+effects: Emacs-26, for `M-x compile`, `M-x shell` or `M-x term`, for Emacs-27
+and Emacs-28 only for `M-x term`.

--- a/docs/content/en/Getting Started/Finding Emacs.md
+++ b/docs/content/en/Getting Started/Finding Emacs.md
@@ -8,14 +8,14 @@ the `emacs` command. To pick a different Emacs, set the environment variable
 `EMACS` to the command name or executable path of the Emacs to use:
 
 ```sh
-$ EMACS="emacs24.1" eask command
+$ EMACS="emacs26.1" eask command
 ```
 
 Note that installed dependencies are scoped on the version of Emacs. So when
 switching between versions you will have to install the dependencies for each:
 
 ```sh
-$ EMACS="emacs24.5" eask install
+$ EMACS="emacs26.5" eask install
 ```
 
 There are, unfortunately, circumstances under which Emacs itself resets the

--- a/src/env.js
+++ b/src/env.js
@@ -28,6 +28,8 @@ global.IS_PKG = path.basename(process.execPath).startsWith('eask');
 /* Environment PATH */
 global.EASK_HOMEDIR = os.homedir().replace(/\\/g, '/') + '/.eask/';
 
+global.EASK_EMACS = process.env.EMACS || process.env.EASK_EMACS || "emacs";
+
 /* Titles */
 global.TITLE_CMD_OPTION = 'Command Options:';
 global.TITLE_PROXY_OPTION = 'Proxy Options:';

--- a/src/util.js
+++ b/src/util.js
@@ -169,7 +169,7 @@ async function e_call(argv, script, ...args) {
   return new Promise(resolve => {
     let _path = el_script(script);
 
-    let cmd_base = ['emacs', '-Q', '--script', _path];
+    let cmd_base = [EASK_EMACS, '-Q', '--script', _path];
     let cmd_args = args.flat();
     let cmd_global = _global_options(argv).flat();
     let cmd = cmd_base.concat(cmd_args).concat(cmd_global);
@@ -184,7 +184,7 @@ async function e_call(argv, script, ...args) {
       console.log('');
     }
     if (5 <= argv.verbose) {  // `all` scope
-      console.log('[EXEC] emacs ' + cmd.join(' '));
+      console.log('[EXEC] ' + EASK_EMACS +  ' ' + cmd.join(' '));
       console.log('');
     }
 


### PR DESCRIPTION
Make use of environment PATH, `EMACS` and `EASK_EMACS`.