### PR TITLE
fix(vcpkg): Use workaround for MODULE_NOT_FOUND error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Add option to init from elisp source file (#183)
 * Print archives progress (#184)
 * Respect package file path in `autoload` command (44c042445bba0dd071d9112e58549437b7ebd58d)
+* fix(vcpkg): Use workaround for `MODULE_NOT_FOUND` error (#187)
 
 ## 0.8.x
 > Released Mar 08, 2023

--- a/lisp/core/run.el
+++ b/lisp/core/run.el
@@ -38,6 +38,11 @@
 (defun eask--export-command (command)
   "Export COMMAND instruction."
   (ignore-errors (make-directory eask-homedir t))  ; generate dir `~/.eask/'
+  ;; XXX: Due to `MODULE_NOT_FOUND` not found error from vcpkg,
+  ;; see https://github.com/vercel/pkg/issues/1356.
+  ;;
+  ;; We must split up all commands!
+  (setq command (eask-s-replace " && " "\n" command))
   (write-region (concat command "\n") nil eask--run-file t))
 
 (defun eask--unmatched-scripts (scripts)


### PR DESCRIPTION
Closes #103 and #104.

Uses the workaround mentioned in https://github.com/vercel/pkg/issues/1356#issuecomment-1145048409.