### PR TITLE
feat(docker): Enter docker directly when no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Respect package file path in `autoload` command (44c042445bba0dd071d9112e58549437b7ebd58d)
 * fix(vcpkg): Use workaround for `MODULE_NOT_FOUND` error (#187)
 * Add docker command (#188)
+* Enter docker directly when no arguments (#191)
 
 ## 0.8.x
 > Released Mar 08, 2023

--- a/cmds/core/docker.js
+++ b/cmds/core/docker.js
@@ -41,7 +41,7 @@ exports.handler = async (argv) => {
   }
 
   let project_dir = convert_path(process.cwd());
-  if (!project_dir.startsWith('/')) {
+  if (!project_dir.startsWith('/')) {  // XXX: Ensure compatible to Unix path!
     project_dir = '/' + project_dir;
   }
   let container_dir = '/' + path.basename(project_dir);
@@ -51,9 +51,15 @@ exports.handler = async (argv) => {
   let default_cmd = ['docker', 'run', '--rm',
                      '-v', container_arg,
                      '-w', container_dir,
-                     'silex/emacs:' + argv.version + '-ci-eask',
-                     'eask'];
+                     'silex/emacs:' + argv.version + '-ci-eask',];
   let rest = process.argv.slice(4);
+
+  // If no argument; we enter the container directly!
+  if (rest.length == 0)
+    default_cmd.splice(2, 0, '-it');
+  else
+    default_cmd.push('eask');
+
   let cmd = default_cmd.concat(rest);
 
   let proc = child_process.spawn(UTIL.cli_args(cmd), { stdio: 'inherit', shell: true });


### PR DESCRIPTION
Shoot a single command:

```sh
$ eask docker 26.1 info   # Same as `eask info` but in the container!
```

Enter docker container without leaving immediately:

```sh
$ eask docker 26.1
```