### PR TITLE
Add PKGBUILD and building instructions

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,19 @@
+pkgname='eask'
+pkgver=$(git tag --sort=-creatordate | head -n1).$(git rev-parse --short HEAD)
+pkgrel=1
+pkgdesc='CLI for building, running, testing, and managing your Emacs Lisp dependencies'
+arch=('x86_64')
+makedepends=('npm')
+url='https://github.com/emacs-eask/cli'
+license=('GPL-3.0')
+
+prepare() {
+    npm i
+    npm run pkg-linux-x64
+}
+
+package() {
+    mkdir -p "$pkgdir/usr/bin"
+    # ATM eask only works when `lisp` dir is installed together with the binary
+    cp -r "${startdir}/lisp" "${startdir}/dist/eask" "$pkgdir/usr/bin"
+}

--- a/docs/content/Getting-Started/Install-Eask/_index.en.md
+++ b/docs/content/Getting-Started/Install-Eask/_index.en.md
@@ -90,6 +90,15 @@ automatically updated.
 $ sudo snap install eask-cli
 ```
 
+### 📦 Arch (Linux)
+
+There's a `PKGBUILD` that builds `eask` from sources and creates a package, so
+inside the top directory of the repository you can simply run:
+
+```sh
+$ makepkg -i
+```
+
 ### 📦 Chocolatey (Windows)
 
 If you have [Chocolatey](https://chocolatey.org/) installed on your machine, you can
@@ -150,7 +159,7 @@ On Windows,
 set PATH=%PATH%;c:/path/to/eask/bin
 ```
 
-Once you have set it up correctly, try `eask --version` then you should see 
+Once you have set it up correctly, try `eask --version` then you should see
 the current eask's version number! 🎉 🎊
 
 

--- a/docs/content/Getting-Started/Install-Eask/_index.en.md
+++ b/docs/content/Getting-Started/Install-Eask/_index.en.md
@@ -141,6 +141,8 @@ $ cd eask-cli
 
 # install the requirements
 $ npm install
+# build from sources. For available targets see `scripts` in `package.json`
+$ npm run pkg-linux-x64
 ```
 
 ### 🏡 Setup

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "which": "^4.0.0",
     "yargs": "^17.0.0"
   },
+  "devDependencies": {
+    "pkg": "^5.0.0"
+  },
   "files": [
     "cmds",
     "src",


### PR DESCRIPTION
Fixes: https://github.com/emacs-eask/cli/issues/215

---------

Two points I'm not sure about:

1. Is putting `PKGBUILD` to the top dir okay?
2. Is `pkg` not being among deps in `package.json` an explicit decision, or an omission that needs to be fixed? In the latter case I'd add a commit that fixes this and would remove the explicit installation of `pkg` that is part of `PKGBUILD` and the `Building from source` sections *(in this PR)*.