### PR TITLE
PKGBUILD: move building command to `build()` function

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,6 +9,9 @@ license=('GPL-3.0')
 
 prepare() {
     npm i
+}
+
+build() {
     npm run pkg-linux-x64
 }
 


### PR DESCRIPTION
I accidentally made the building command part of `prepare()` function which is not correct as various `pacman` options that a user may want to use operate on these functions. Let's fix that.