### PR TITLE
PKGBUILD: avoid stripping the `eask` binary

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,6 +4,7 @@ pkgrel=1
 pkgdesc='CLI for building, running, testing, and managing your Emacs Lisp dependencies'
 arch=('x86_64')
 makedepends=('npm')
+options=('!strip') # node puts scripts into debug section, so we can't strip it
 url='https://github.com/emacs-eask/cli'
 license=('GPL-3.0')
 


### PR DESCRIPTION
Node puts scripts to some ELF sections, so we can't strip these. Strictly speaking, judging by the offsets they seem to be put into .dynstr section, but leaving that section unstripped doesn't make the error

        Pkg: Error reading from file

…go away. Unless someone is motivated to dig into the list of sections to be put to `STRIP_BINARIES`, let's just disable it.

Fixes: https://github.com/emacs-eask/cli/issues/248