### PR TITLE
Fix: match behavior of declare linter to checkdoc

### DIFF
--- a/lisp/lint/declare.el
+++ b/lisp/lint/declare.el
@@ -34,7 +34,7 @@
          (errors))
     (eask-lint-first-newline)
     (eask-msg "`%s` with check-declare" (ansi-green file))
-    (setq errors (check-declare-file filename))
+    (setq errors (dlet ((inhibit-message 't)) (check-declare-file filename)))
     (if errors
         (with-current-buffer check-declare-warning-buffer
           (eask-report (string-remove-prefix "\n" (buffer-string))))

--- a/lisp/lint/declare.el
+++ b/lisp/lint/declare.el
@@ -39,7 +39,7 @@
          (errors))
     (eask-lint-first-newline)
     (eask-msg "`%s` with check-declare" (ansi-green file))
-    (setq errors (dlet ((inhibit-message 't)) (check-declare-file filename)))
+    (setq errors (eask--silent (check-declare-file filename)))
     (if errors
         (with-current-buffer check-declare-warning-buffer
           (eask-report (string-remove-prefix "\n" (buffer-string))))

--- a/lisp/lint/declare.el
+++ b/lisp/lint/declare.el
@@ -37,7 +37,7 @@
     (setq errors (check-declare-file filename))
     (if errors
         (with-current-buffer check-declare-warning-buffer
-          (eask-msg (buffer-string)))
+          (eask-report (string-remove-prefix "\n" (buffer-string))))
       (eask-msg "No issues found"))))
 
 (eask-start

--- a/lisp/lint/declare.el
+++ b/lisp/lint/declare.el
@@ -25,6 +25,11 @@
 (defvar check-declare-warning-buffer)
 
 ;;
+;;; Flags
+
+(advice-add #'eask-allow-error-p :override #'always)
+
+;;
 ;;; Core
 
 (defun eask-lint-declare--file (filename)


### PR DESCRIPTION
Fixes #271 

### Summary
* --strict formats warnings like errors and exits with status 1
* extra message output of `check-declare-file` is hidden
* set allow-errors to 'always' in code so that all files are linted

After the change:
```shell
> ~/git/eask-cli/bin/eask lint declare --strict
`js-comint.el` with check-declare
js-comint.el:148:Warning (check-declare): said ‘nvm--find-exact-version-for’ was defined in .eask/31.0.50/elpa/nvm-20240921.1901/nvm.el: arglist mismatch


`test-js-comint.el` with check-declare
No issues found

(Total of 2 files have checked)
```
The output line is formatted like an error and the exit code is 1.

### Questions
Perhaps 'Warning (check-declare)' should be removed from the output?
e.g. this seems like a better message
```
js-comint.el:148: ‘nvm--find-exact-version-for’ was defined in .eask/31.0.50/elpa/nvm-20240921.1901/nvm.el: arglist mismatch
```