### PR TITLE
Add exit code tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ command-local:
 command-analyze:
 	./test/checker/dsl/run.sh
 	./test/checker/metadata/run.sh
+	./test/commands/analyze/run.sh
 
 command-docker:
 	./test/commands/docker/run.sh

--- a/test/commands/analyze/Eask-error
+++ b/test/commands/analyze/Eask-error
@@ -1,0 +1,2 @@
+(package "" "" "")
+(scrog "unrecognized")

--- a/test/commands/analyze/Eask-normal
+++ b/test/commands/analyze/Eask-normal
@@ -1,0 +1,2 @@
+(package "check-dsl" "0.0.1" "Test for DSL")
+(keywords "dsl")

--- a/test/commands/analyze/Eask-warn
+++ b/test/commands/analyze/Eask-warn
@@ -1,0 +1,5 @@
+(package "check-dsl" "0.0.1" "Test for DSL")
+
+(keywords "dsl")
+
+(package-file "none.el")

--- a/test/commands/analyze/run.sh
+++ b/test/commands/analyze/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2022-2024 the Eask authors.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+## Commentary:
+#
+# Tests "analyze" command's option handling and error behaviour.
+# See the tests in the test/checker directory too.
+
+set -e
+
+source ./test/fixtures/home/scripts/testing.sh
+
+cd $(dirname "$0")
+
+# Eask-normal - no errors or warnings
+# Eask-warn   - only warnings
+# Eask-error  - errors and  warnings
+
+should_run eask analyze Eask-normal
+
+should_run eask analyze Eask-warn
+
+should_error eask analyze Eask-error
+
+should_error eask analyze Eask-warn --strict
+
+# sanity check: flag should not change behavior in this case
+should_error eask analyze Eask-error --allow-error
+
+# Should report that Eask-normal was tested
+OUTPUT=$(should_error eask analyze --allow-error Eask-normal Eask-error)
+echo "$OUTPUT"
+should_match "(Checked 2 files)" "$OUTPUT"
+
+# Can also use a more concise form, but it doesn't print the output
+# should_match "(Checked 2 files)" "$(should_error eask analyze --allow-error Eask-normal Eask-error)"

--- a/test/fixtures/home/scripts/testing.sh
+++ b/test/fixtures/home/scripts/testing.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Test reporting functions
+# This file will be sourced by other shell test scripts.
+# Expects to run with set -e
+
+# TODO note that eask output is always to stderr
+
+# Run command and exit with the same status
+# All args interpreted as program to run
+# e.g. should_run cmd arg1 arg2 ...
+should_run() {
+    echo "Run: $*"
+    echo "---------------"
+    "$@" 2>&1 | cat
+    local TEST_STATUS=${PIPESTATUS[0]}
+
+    echo ""
+
+    if [ $TEST_STATUS -gt 0 ]; then
+        printf "Fail: \'%s\' exited with status %s\n" "$*" "$TEST_STATUS" >&2
+        exit 1
+    fi
+}
+
+# Run command and exit with non-zero if command exits with zero.
+# All args interpreted as program to run
+# e.g. should_error cmd arg1 arg2 ...
+should_error() {
+    echo "Run: $*"
+    echo "---------------"
+    # a shorter alternative is
+    # ! "$@" || (echo "failed" && exit 1)
+
+    # this version allow for more formatting
+    "$@" 2>&1 | cat  # Exit status of individual commands in a pipeline are ignored
+    local TEST_STATUS=${PIPESTATUS[0]} # Get the true status, $? will always be 0
+
+    echo ""
+
+    if [ $TEST_STATUS -eq 0 ]; then
+        printf "Fail: \'%s\' should exit with non-zero status\n" "$*" >&2
+        exit 1
+    fi
+}
+
+# Check if (grep) pattern ARG1 is found in string ARG2
+# E.g. should_match "foo*" "foobar"
+should_match() {
+    echo "$1" | grep "$2"  - | true
+    local SEARCH_RES=${PIPESTATUS[1]}
+
+    if [ $SEARCH_RES -gt 0 ]; then
+        printf "Fail: Output did not match \'%s\'\n" "$1"
+        exit 1
+    fi
+}


### PR DESCRIPTION
Before changing the behavior of errors as discussed in #273 , I wanted to add more tests that check the current behavior.

This PR adds tests which check, for each command:
- bad input exits with error
- input with warnings exits with error when `--strict` is set
- multiple inputs (i.e. commands which apply to multiple files or have multiple steps) should execute as far as possible
  when `--allow-error` is set, then exit with error

I'll add some script helpers that check error statuses and note any discrepancies I see.
I'll comment out and mark any currently failing expectations with `#FIXME` so that the CI run is clean.