### PR TITLE
Fix some typos in help messages and command doco

### DIFF
--- a/cmds/core/install-deps.js
+++ b/cmds/core/install-deps.js
@@ -22,7 +22,7 @@ exports.desc = 'Automatically install package dependencies';
 exports.builder = yargs => yargs
   .options({
     'development': {
-      description: 'install include development dependencies',
+      description: 'also install development dependencies',
       alias: 'dev',
       type: 'boolean',
       group: TITLE_CMD_OPTION,

--- a/docs/content/Getting-Started/Basic-Usage/_index.en.md
+++ b/docs/content/Getting-Started/Basic-Usage/_index.en.md
@@ -89,7 +89,7 @@ Options:
   -f, --force        enable force flag                                                                                                                                                                  [boolean]
       --debug        turn on debug mode                                                                                                                                                                 [boolean]
       --strict       report error instead of warnings                                                                                                                                                   [boolean]
-      --allow-error  continue the executioon even there is error reported                                                                                                                               [boolean]
+      --allow-error  attempt to continue execution on error                                                                                                                                             [boolean]
       --insecure     allow insecure connection                                                                                                                                                          [boolean]
       --no-color     enable/disable color output                                                                                                                                                        [boolean]
   -v, --verbose      set verbosity from 0 to 5                                                                                                                                                           [number]

--- a/docs/content/Getting-Started/Basic-Usage/_index.zh-tw.md
+++ b/docs/content/Getting-Started/Basic-Usage/_index.zh-tw.md
@@ -86,7 +86,7 @@ Options:
   -f, --force        enable force flag                                                                                                                                                                  [boolean]
       --debug        turn on debug mode                                                                                                                                                                 [boolean]
       --strict       report error instead of warnings                                                                                                                                                   [boolean]
-      --allow-error  continue the executioon even there is error reported                                                                                                                               [boolean]
+      --allow-error  attempt to continue execution on error                                                                                                                                             [boolean]
       --insecure     allow insecure connection                                                                                                                                                          [boolean]
       --no-color     enable/disable color output                                                                                                                                                        [boolean]
   -v, --verbose      set verbosity from 0 to 5                                                                                                                                                           [number]

--- a/eask
+++ b/eask
@@ -61,7 +61,7 @@ yargs
       type: 'boolean',
     },
     'allow-error': {
-      description: `continue the executioon even there is error reported`,
+      description: `attempt to continue execution on error`,
       type: 'boolean',
     },
     'insecure': {

--- a/lisp/core/archives.el
+++ b/lisp/core/archives.el
@@ -48,7 +48,7 @@
     (eask-info "(Total of %s archive%s available)" (length eask-source-mapping)
                (eask--sinr eask-source-mapping "" "s")))
    (package-archives
-    (eask-info "In used archives:")
+    (eask-info "Archives in use:")
     (eask-msg "")
     (eask-archive--print-alist package-archives)
     (eask-info "(Total of %s archive%s listed)" (length package-archives)

--- a/lisp/help/link/add/success/eask
+++ b/lisp/help/link/add/success/eask
@@ -1,7 +1,7 @@
 
 ✓ You have now created the link, here are things you might want to consider:
 
-  - [ ] (Optional) Compile source package with `.elc` files   Use `.elc` may be metter choice
+  - [ ] (Optional) Compile source package with `.elc` files
 
 If the source package uses Eask, you can use `eask` commands to accomplish these tasks.
 

--- a/lisp/help/link/add/success/pkg
+++ b/lisp/help/link/add/success/pkg
@@ -1,10 +1,10 @@
 
 ✓ You have now created the link, here are things you might want to consider:
-  
+
   - [ ] (Optional) `SOURCE-autoloads.el`                      Package autoloads
-  - [ ] (Optional) Compile source package with `.elc` files   Use `.elc` may be metter choice
+  - [ ] (Optional) Compile source package with `.elc` files
 
 If the source package uses Eask, you can use `eask` commands to accomplish these tasks.
-   
+
   * `eask generate autoloads`
   * `eask compile`

--- a/lisp/help/run/script
+++ b/lisp/help/run/script
@@ -1,4 +1,4 @@
 
-💡 Make sure you have specify a (scripts ..) directive inside your Eask file!
-   
-    [+] (scripts "test" "echo This is a test command!")
+💡 Make sure you have a (script ..) directive inside your Eask file!
+
+    [+] (script "test" "echo This is a test command!")

--- a/lisp/link/add.el
+++ b/lisp/link/add.el
@@ -39,7 +39,7 @@
     (when (file-exists-p link-path)
       (eask-msg "")
       (eask-with-progress
-        (ansi-yellow "!! The link is already presented; override the existing link... ")
+        (ansi-yellow "!! The link is already present; overriding the existing link... ")
         (eask-link-delete-symlink link-path)
         (ansi-yellow "done !!")))
     (make-symbolic-link source link-path)
@@ -104,12 +104,12 @@
                     (format "  - [1/2] Generating %s file... " autoloads-file)
                     (unless autoloads-file-presented
                       (eask-with-verbosity 'debug (eask-call "generate/autoloads")))
-                    (if autoloads-file-presented "already presented ✗" "done ✓"))
+                    (if autoloads-file-presented "already present ✗" "done ✓"))
                   (eask-with-progress
                     (format "  - [2/2] Generating %s file... " pkg-file)
                     (unless pkg-file-presented
                       (eask-with-verbosity 'debug (eask-call "generate/pkg-file")))
-                    (if pkg-file-presented "already presented ✗" "done ✓")))
+                    (if pkg-file-presented "already present ✗" "done ✓")))
                 (eask-link-add--create source)
                 (when (and (zerop (length links))         ; if no link previously,
                            (= 1 (length (eask-link-list))))  ; and first link created!

--- a/lisp/link/delete.el
+++ b/lisp/link/delete.el
@@ -51,7 +51,7 @@
       (eask-help "link/delete"))
      ;; No link to delete
      ((zerop (length links))
-      (eask-info "No links presented; tasks ended with no operation"))
+      (eask-info "No links present; task ended with no operation"))
      ;; Link not found
      ((cl-some (lambda (name)
                  (not (member name link-names)))


### PR DESCRIPTION
Just fixing some typos I noticed while adding exit code tests.