### PR TITLE
Fix `eask-test-ert--message` breaks tests which trigger minibuffer

### DIFF
--- a/lisp/test/ert.el
+++ b/lisp/test/ert.el
@@ -31,6 +31,10 @@ Arguments FNC and ARGS are used for advice `:around'."
   (if eask-test-ert--message-loop (apply fnc args)
     (let ((eask-test-ert--message-loop t))
       (cond
+       ;; (message nil) is used to clear the minibuffer
+       ;; However, format requires the first argument to be a format string
+       ((null (car args))
+        (apply fnc args))
        ((string-match-p "^[ ]+FAILED " (apply #'format args))
         (eask-msg (ansi-red (apply #'format args))))
        ((string-match-p "^[ ]+SKIPPED " (apply #'format args))

--- a/test/commands/test/ert/run.sh
+++ b/test/commands/test/ert/run.sh
@@ -26,3 +26,7 @@ echo "Test command 'ert'..."
 cd $(dirname "$0")
 
 eask test ert ./test/*.el
+
+# regression
+echo "Test ert: nil message"
+eask test ert ./test-nil-message/*.el

--- a/test/commands/test/ert/test-nil-message/ert-test.el
+++ b/test/commands/test/ert/test-nil-message/ert-test.el
@@ -1,6 +1,6 @@
 ;;; ert-test.el --- Test the command ert      -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2022-2024  the Eask authors.
+;; Copyright (C) 2024  the Eask authors.
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -25,5 +25,5 @@
 (require 'debug)
 
 (ert-deftest ert-test-1 ()
-  (should (= 1 1)))
+  (should-not (message nil)))
 ;;; ert-test.el ends here


### PR DESCRIPTION
From the doco: `(message nil)` can be used to clear the minibuffer.

However, `eask-test-ert--message` is advised on `message` when running `eask test ert` and passes all `message` args to `format`, which requires a format string.

The provided test incorrectly fails with a signal (it should succeed)
```elisp
(ert-deftest ert-test-1 ()
  (should-not (message nil)))
```

The backtrace is like
```
Test ert-test-1 backtrace:
  format(nil)
  apply(format nil)
  (string-match-p "^[ ]+FAILED " (apply #'format args))
  (cond ((string-match-p "^[ ]+FAILED " (apply #'format args)) (eask-m
  (let ((eask-test-ert--message-loop t)) (cond ((string-match-p "^[ ]+
  (if eask-test-ert--message-loop (apply fnc args) (let ((eask-test-er
  eask-test-ert--message(#<subr message> nil)
  apply(eask-test-ert--message #<subr message> nil)
  message(nil)
  apply(message nil)
...
```

Fixed by passing the nil argument to `message`. This does not appear to create extra messages in Eask output.