### PR TITLE
ci: No need to explicit install pkg globally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,8 @@ jobs:
       with:
         tag: v2.1.5-procursus7
 
-    - name: Install pkg
-      run: npm install -g @yao-pkg/pkg
-
     - name: Preparing...
-      run: npm install
+      run: npm install --include=dev
 
     - name: Building...
       run: npm run-script pkg-${{ matrix.target }}


### PR DESCRIPTION
I don't think this is needed?