### PR TITLE
remove `$ ` prefix from all Markdown documentation commands

### DIFF
--- a/docs/content/Contributing/Developing-Eask/_index.en.md
+++ b/docs/content/Contributing/Developing-Eask/_index.en.md
@@ -24,7 +24,7 @@ method. Make sure you have set up the environment PATH variable, so you can call
 After you have stepped through the installation, try:
 
 ```sh
-$ eask locate
+eask locate
 ```
 
 It should print out the location of the `eask` executable.

--- a/docs/content/Contributing/Developing-Eask/_index.zh-tw.md
+++ b/docs/content/Contributing/Developing-Eask/_index.zh-tw.md
@@ -22,7 +22,7 @@ weight: 20
 完成安裝後，嘗試：
 
 ```sh
-$ eask locate
+eask locate
 ```
 
 它應該會列印出 `eask` 可執行檔的位置。即使您已安裝多個 Eask 版本，也應該可以辨識 Eask 可執行檔的位置！

--- a/docs/content/Development-API/_index.en.md
+++ b/docs/content/Development-API/_index.en.md
@@ -74,7 +74,7 @@ Return non-nil if Eask is packaged.
 Eask's arguments after command separator `--'; return a list.
 
 ```sh
-$ eask <command> -- args0 args1
+eask <command> -- args0 args1
 ```
 
 Output:
@@ -88,7 +88,7 @@ Output:
 Eask's arguments after command separator `--'; return a string.
 
 ```sh
-$ eask <command> -- args0 args1
+eask <command> -- args0 args1
 ```
 
 Output:
@@ -120,7 +120,7 @@ Return the working directory of the program going to be executed.
 Return the current command in string. Suppose the command is:
 
 ```sh
-$ eask init
+eask init
 ```
 
 then,
@@ -291,7 +291,7 @@ Return a command-line argument by index.
 Return a list that is extracted from command-line arguments.
 
 ```sh
-$ eask info --verbose 4 foo bar
+eask info --verbose 4 foo bar
 ```
 
 It will ignore `--verbose` and `4`, and only returns `foo`, and `bar`.
@@ -535,10 +535,10 @@ Return `t` if the `insecure` option is enabled.
 Return a **string** represents `hostname` + `port number`.
 
 ```sh
-$ eask [command] --proxy "localhost:1000"
-$ eask [command] --http-proxy "localhost:2000"
-$ eask [command] --https-proxy "localhost:3000"
-$ eask [command] --no-proxy "localhost:4000"
+eask [command] --proxy "localhost:1000"
+eask [command] --http-proxy "localhost:2000"
+eask [command] --https-proxy "localhost:3000"
+eask [command] --no-proxy "localhost:4000"
 ```
 
 ## 🔍 Function: eask-destination ()
@@ -751,7 +751,7 @@ Weather to generate log files. (default: `nil`)
 Use command `cat` to see the log,
 
 ```
-$ cat /.log/messages.log
+cat /.log/messages.log
 ```
 
 ## 🔍 Variable: eask-level-color

--- a/docs/content/Development-API/_index.zh-tw.md
+++ b/docs/content/Development-API/_index.zh-tw.md
@@ -73,7 +73,7 @@ Eask的呼叫程式路徑。
 命令分隔符號 `--` 之後的 Eask 參數；傳回一個列表。
 
 ```sh
-$ eask <command> -- args0 args1
+eask <command> -- args0 args1
 ```
 
 輸出:
@@ -87,7 +87,7 @@ $ eask <command> -- args0 args1
 命令分隔符號 `--` 之後的 Eask 參數；傳回一個字串。
 
 ```sh
-$ eask <command> -- args0 args1
+eask <command> -- args0 args1
 ```
 
 輸出:
@@ -119,7 +119,7 @@ $ eask <command> -- args0 args1
 返回字符串中的當前命令。假設命令是：
 
 ```sh
-$ eask init
+eask init
 ```
 
 然後，
@@ -287,7 +287,7 @@ $ eask init
 返回從命令行參數中提取的列表。
 
 ```sh
-$ eask info --verbose 4 foo bar
+eask info --verbose 4 foo bar
 ```
 
 它會忽略 `--verbose` 和 `4`，只返回 `foo` 和 `bar`。
@@ -529,10 +529,10 @@ $ eask info --verbose 4 foo bar
 返回一個 **string** 表示 `hostname` + `port number`。
 
 ```sh
-$ eask [command] --proxy "localhost:1000"
-$ eask [command] --http-proxy "localhost:2000"
-$ eask [command] --https-proxy "localhost:3000"
-$ eask [command] --no-proxy "localhost:4000"
+eask [command] --proxy "localhost:1000"
+eask [command] --http-proxy "localhost:2000"
+eask [command] --https-proxy "localhost:3000"
+eask [command] --no-proxy "localhost:4000"
 ```
 
 ## 🔍 函式: eask-destination ()
@@ -743,7 +743,7 @@ Output:
 使用命令 `cat` 查看日誌，
 
 ```
-$ cat /.log/messages.log
+cat /.log/messages.log
 ```
 
 ## 🔍 變數: eask-level-color

--- a/docs/content/Getting-Started/Advanced-Usage/_index.en.md
+++ b/docs/content/Getting-Started/Advanced-Usage/_index.en.md
@@ -33,7 +33,7 @@ For example, to consider warnings as errors when byte-compiling with the command
 This is also equivalent to option `--strict`:
 
 ```sh
-$ eask compile [FILES..] --strict
+eask compile [FILES..] --strict
 ```
 
 Or hooks that run on every command:
@@ -50,8 +50,8 @@ Or hooks that run on every command:
 For subcommands that contain spaces, will concatenate with `/`:
 
 ```sh
-$ eask lint checkdoc     # lint/checkdoc
-$ eask generate license  # generate/license
+eask lint checkdoc     # lint/checkdoc
+eask generate license  # generate/license
 ```
 
 therefore,

--- a/docs/content/Getting-Started/Advanced-Usage/_index.zh-tw.md
+++ b/docs/content/Getting-Started/Advanced-Usage/_index.zh-tw.md
@@ -30,7 +30,7 @@ weight: 400
 這也等同於選項 `--strict`：
 
 ```sh
-$ eask compile [FILES..] --strict
+eask compile [FILES..] --strict
 ```
 
 或者在每個命令上運行的 hooks：
@@ -47,8 +47,8 @@ $ eask compile [FILES..] --strict
 對於包含空格的子命令，將與`/`連接：
 
 ```sh
-$ eask lint checkdoc     # lint/checkdoc
-$ eask generate license  # generate/license
+eask lint checkdoc     # lint/checkdoc
+eask generate license  # generate/license
 ```
 
 所以，

--- a/docs/content/Getting-Started/Basic-Usage/_index.en.md
+++ b/docs/content/Getting-Started/Basic-Usage/_index.en.md
@@ -14,7 +14,7 @@ Once you have installed [Eask][], make sure it is in your `PATH`. You can test
 that Eask has been installed correctly via the help command:
 
 ```
-$ eask --help
+eask --help
 ```
 
 {{< hint ok >}}
@@ -103,20 +103,20 @@ The most common usage is probably to run eask with your current directory being
 the input directory. Then you run eask followed by a subcommand:
 
 ```sh
-$ eask info             # Print out Eask-file information
+eask info             # Print out Eask-file information
 ```
 
 Notice the subcommand can be nested:
 
 ```sh
-$ eask clean workspace  # Deletes your `.eask` folder
+eask clean workspace  # Deletes your `.eask` folder
 ```
 
 Pass in option `--help` to look up more information regarding the command you
 are using:
 
 ```sh
-$ eask clean --help
+eask clean --help
 ```
 
 The output, and it shows there are 7 subcommands supported:
@@ -183,7 +183,7 @@ Eask is more than a build tool now. Several commands don't require their
 dependencies as package dependencies. For example, the `cat` command:
 
 ```sh
-$ eask cat [PATTERNS..]
+eask cat [PATTERNS..]
 ```
 
 `cat` is a simple command that mimics Linux's default `cat` command, but it does

--- a/docs/content/Getting-Started/Basic-Usage/_index.zh-tw.md
+++ b/docs/content/Getting-Started/Basic-Usage/_index.zh-tw.md
@@ -12,7 +12,7 @@ Eask 的 CLI 功能齊全但易於使用，即使對於那些使用命令行的�
 一旦你安裝了 [Eask][]，確保它在你的 `PATH` 中。 您可以通過 help 命令測試 Eask 是否已正確安裝：
 
 ```
-$ eask --help
+eask --help
 ```
 
 {{< hint ok >}}
@@ -99,19 +99,19 @@ For more information, find the manual at https://emacs-eask.github.io/
 最常見的用法可能是在當前目錄作為輸入目錄的情況下運行 eask。 然後你運行 eask 後跟一個子命令：
 
 ```sh
-$ eask info             # 打印出 Eask 文件信息
+eask info             # 打印出 Eask 文件信息
 ```
 
 Notice the subcommand can be nested:
 
 ```sh
-$ eask clean workspace  # 刪除你的 .eask 文件夾
+eask clean workspace  # 刪除你的 .eask 文件夾
 ```
 
 傳遞選項 `--help` 以查找有關您正在使用的命令的更多信息：
 
 ```sh
-$ eask clean --help
+eask clean --help
 ```
 
 輸出，它顯示支持 7 個子命令：
@@ -173,7 +173,7 @@ Eask 創建了一個隔離的環境，因此在播放、測試和運行您的 el
 Eask 現在不僅僅是一個構建工具。 一些命令不需要它們的依賴項作為包依賴項。 例如，`cat` 命令：
 
 ```sh
-$ eask cat [PATTERNS..]
+eask cat [PATTERNS..]
 ```
 
 `cat` 是一個模仿 Linux 的默認 `cat` 命令的簡單命令，但它會為您突出顯示語法！ 它是如何實施的？

--- a/docs/content/Getting-Started/Commands-and-options/_index.en.md
+++ b/docs/content/Getting-Started/Commands-and-options/_index.en.md
@@ -8,7 +8,7 @@ weight: 300
 The general syntax of the **eask** program is:
 
 ```sh
-$ eask [GLOBAL-OPTIONS] [COMMAND] [COMMAND-OPTIONS] [COMMAND-ARGUMENTS]
+eask [GLOBAL-OPTIONS] [COMMAND] [COMMAND-OPTIONS] [COMMAND-ARGUMENTS]
 ```
 
 # 🚩 Creating
@@ -18,7 +18,7 @@ $ eask [GLOBAL-OPTIONS] [COMMAND] [COMMAND-OPTIONS] [COMMAND-ARGUMENTS]
 Create a new elisp project with the default `Eask`-file and CI/CD support.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] create package <name>
+eask [GLOBAL-OPTIONS] create package <name>
 ```
 
 {{< hint info >}}
@@ -30,7 +30,7 @@ $ eask [GLOBAL-OPTIONS] create package <name>
 Create a new ELPA using [github-elpa](https://github.com/10sr/github-elpa).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] create elpa <name>
+eask [GLOBAL-OPTIONS] create elpa <name>
 ```
 
 {{< hint info >}}
@@ -46,7 +46,7 @@ Often use commands that are uncategorized.
 Initialize the current directory to start using Eask.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] init
+eask [GLOBAL-OPTIONS] init
 ```
 
 Eask will generate the file like this:
@@ -72,25 +72,25 @@ Eask will generate the file like this:
 `.el` file to Eask-file:
 
 ```
-$ eask init --from source /path/to/source.el
+eask init --from source /path/to/source.el
 ```
 
 If you already have a [Cask][] project, you can convert Cask-file to Eask-file:
 
 ```
-$ eask init --from cask /path/to/Cask
+eask init --from cask /path/to/Cask
 ```
 
 If you already have a [Eldev][] project, you can convert Eldev-file to Eask-file:
 
 ```
-$ eask init --from eldev /path/to/Eldev
+eask init --from eldev /path/to/Eldev
 ```
 
 If you already have a [Keg][] project, you can convert Keg-file to Eask-file:
 
 ```
-$ eask init --from keg /path/to/Keg
+eask init --from keg /path/to/Keg
 ```
 
 {{< hint ok >}}
@@ -103,7 +103,7 @@ Eask-file examples!
 Show information about the project or configuration.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] info
+eask [GLOBAL-OPTIONS] info
 ```
 
 ## 🔍 eask status
@@ -111,7 +111,7 @@ $ eask [GLOBAL-OPTIONS] info
 Display the state of the workspace.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] status
+eask [GLOBAL-OPTIONS] status
 ```
 
 ## 🔍 eask install-deps
@@ -121,7 +121,7 @@ To install all dependencies.
 Alias: `install-dependencies`, `prepare`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] install-deps [--dev]
+eask [GLOBAL-OPTIONS] install-deps [--dev]
 ```
 
 {{< hint ok >}}
@@ -133,19 +133,19 @@ $ eask [GLOBAL-OPTIONS] install-deps [--dev]
 To install packages.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] install [PACKAGES..]
+eask [GLOBAL-OPTIONS] install [PACKAGES..]
 ```
 
 Install packages by specifying arguments:
 
 ```sh
-$ eask install auto-complete helm magit
+eask install auto-complete helm magit
 ```
 
 Or else, it will install the package from the current development:
 
 ```sh
-$ eask install
+eask install
 ```
 
 ## 🔍 eask uninstall
@@ -153,19 +153,19 @@ $ eask install
 To uninstall/delete packages.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] uninstall [PACKAGES..]
+eask [GLOBAL-OPTIONS] uninstall [PACKAGES..]
 ```
 
 Uninstall packages by specifying arguments:
 
 ```sh
-$ eask uninstall dash f s
+eask uninstall dash f s
 ```
 
 Or else, it will uninstall the package from the current development:
 
 ```sh
-$ eask uninstall
+eask uninstall
 ```
 
 ## 🔍 eask package
@@ -175,7 +175,7 @@ Build the package artifact.
 Alias: `pack`
 
 ```sh
-$ eask package [DESTINATION]
+eask package [DESTINATION]
 ```
 
 If [DESTINATION] is not specified, it will generate to the `/dist` folder
@@ -186,19 +186,19 @@ by default.
 Byte-compile `.el` files.
 
 ```sh
-$ eask compile [FILES..]
+eask compile [FILES..]
 ```
 
 Compile files by specifying arguments:
 
 ```sh
-$ eask compile file-1.el file-2.el
+eask compile file-1.el file-2.el
 ```
 
 Or compile files that are already specified in your `Eask`-file.
 
 ```sh
-$ eask compile
+eask compile
 ```
 
 ## 🔍 eask recompile
@@ -206,7 +206,7 @@ $ eask compile
 Byte-recompile `.el` files.
 
 ```sh
-$ eask recompile [FILES..]
+eask recompile [FILES..]
 ```
 
 {{< hint info >}}
@@ -219,7 +219,7 @@ compiling.
 Print path to package directory, where all dependencies are installed.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] package-directory
+eask [GLOBAL-OPTIONS] package-directory
 ```
 
 ## 🔍 eask path
@@ -229,7 +229,7 @@ Print the `PATH` environment variable of this project.
 Alias: `exec-path`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] path [PATTERNS..]
+eask [GLOBAL-OPTIONS] path [PATTERNS..]
 ```
 
 Optionally, you can pass in `[PATTERNS..]` to perform the search.
@@ -239,7 +239,7 @@ Optionally, you can pass in `[PATTERNS..]` to perform the search.
 Print the load path containing the dependencies of the current project.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] load-path [PATTERNS..]
+eask [GLOBAL-OPTIONS] load-path [PATTERNS..]
 ```
 
 Optionally, you can pass in `[PATTERNS..]` to perform the search.
@@ -249,7 +249,7 @@ Optionally, you can pass in `[PATTERNS..]` to perform the search.
 Print the list of all package files.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] files [PATTERNS..]
+eask [GLOBAL-OPTIONS] files [PATTERNS..]
 ```
 
 If `[PATTERNS..]` are defined, it will display files that match that pattern.
@@ -259,7 +259,7 @@ If `[PATTERNS..]` are defined, it will display files that match that pattern.
 Suggest a recipe format.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] recipe [FILES..]
+eask [GLOBAL-OPTIONS] recipe [FILES..]
 ```
 
 ## 🔍 eask keywords
@@ -267,7 +267,7 @@ $ eask [GLOBAL-OPTIONS] recipe [FILES..]
 List available keywords that can be used in the header section.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] keywords
+eask [GLOBAL-OPTIONS] keywords
 ```
 
 ## 🔍 eask bump
@@ -275,7 +275,7 @@ $ eask [GLOBAL-OPTIONS] keywords
 Bump version for your project and/or Eask-file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] bump [LEVELS..]
+eask [GLOBAL-OPTIONS] bump [LEVELS..]
 ```
 
 {{< hint info >}}
@@ -289,7 +289,7 @@ View filename(s).
 The positional argument `[PATTERNS..]` is an array of wildcard patterns.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] cat [PATTERNS..]
+eask [GLOBAL-OPTIONS] cat [PATTERNS..]
 ```
 
 {{< hint info >}}
@@ -302,7 +302,7 @@ to accomplish the syntax highlighting.
 Concatenate all Emacs Lisp files into one file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] concat [FILES..]
+eask [GLOBAL-OPTIONS] concat [FILES..]
 ```
 
 ## 🔍 eask loc
@@ -310,7 +310,7 @@ $ eask [GLOBAL-OPTIONS] concat [FILES..]
 Print LOC information.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] loc [FILES..]
+eask [GLOBAL-OPTIONS] loc [FILES..]
 ```
 
 # 🚩 Documentation
@@ -322,7 +322,7 @@ Commands used to build documentation site.
 Build documentation.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] docs [NAMES..]
+eask [GLOBAL-OPTIONS] docs [NAMES..]
 ```
 
 # 🚩 Execution
@@ -336,7 +336,7 @@ Basically, this allows you to do anything you want!
 Load Emacs Lisp files in order.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] load [FILES..]
+eask [GLOBAL-OPTIONS] load [FILES..]
 ```
 
 ## 🔍 eask exec
@@ -344,7 +344,7 @@ $ eask [GLOBAL-OPTIONS] load [FILES..]
 Execute the system command with the given arguments.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] exec [COMMAND] [ARGUMENTS ...]
+eask [GLOBAL-OPTIONS] exec [COMMAND] [ARGUMENTS ...]
 ```
 
 ## 🔍 eask emacs
@@ -352,7 +352,7 @@ $ eask [GLOBAL-OPTIONS] exec [COMMAND] [ARGUMENTS ...]
 Execute emacs with the appropriate environment.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
+eask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
 ```
 
 ## 🔍 eask eval
@@ -360,7 +360,7 @@ $ eask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
 Evaluate `FORM` as a lisp form.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] eval [FORM]
+eask [GLOBAL-OPTIONS] eval [FORM]
 ```
 
 ## 🔍 eask repl
@@ -368,7 +368,7 @@ $ eask [GLOBAL-OPTIONS] eval [FORM]
 Start the Elisp REPL.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] repl [FILES..]
+eask [GLOBAL-OPTIONS] repl [FILES..]
 ```
 
 Alias: `ielm`
@@ -378,7 +378,7 @@ Alias: `ielm`
 Run the script.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] run script [NAMES..]
+eask [GLOBAL-OPTIONS] run script [NAMES..]
 ```
 
 ## 🔍 eask run command
@@ -388,7 +388,7 @@ Run the command.
 Alias: `cmd`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] run command [NAMES..]
+eask [GLOBAL-OPTIONS] run command [NAMES..]
 ```
 
 ## 🔍 eask docker
@@ -396,13 +396,13 @@ $ eask [GLOBAL-OPTIONS] run command [NAMES..]
 Launch specified Emacs version in a Docker container.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] docker <VERSION> [ARGUMENTS ...]
+eask [GLOBAL-OPTIONS] docker <VERSION> [ARGUMENTS ...]
 ```
 
 For example:
 
 ```sh
-$ eask docker 26.1 info
+eask docker 26.1 info
 ```
 
 This is the same as jumping right into Emacs 26.1 (in docker) and executing
@@ -417,7 +417,7 @@ Commands that help you manage your package's dependencies.
 List out all package archives.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] archives
+eask [GLOBAL-OPTIONS] archives
 ```
 
 ## 🔍 eask search
@@ -425,7 +425,7 @@ $ eask [GLOBAL-OPTIONS] archives
 Search packages from archives.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] search [QUEIRES..]
+eask [GLOBAL-OPTIONS] search [QUEIRES..]
 ```
 
 ## 🔍 eask upgrade
@@ -433,7 +433,7 @@ $ eask [GLOBAL-OPTIONS] search [QUEIRES..]
 Upgrade all packages.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] upgrade
+eask [GLOBAL-OPTIONS] upgrade
 ```
 
 ## 🔍 eask list
@@ -441,7 +441,7 @@ $ eask [GLOBAL-OPTIONS] upgrade
 List packages.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] list [--depth]
+eask [GLOBAL-OPTIONS] list [--depth]
 ```
 
 ## 🔍 eask outdated
@@ -449,7 +449,7 @@ $ eask [GLOBAL-OPTIONS] list [--depth]
 List out all outdated packages.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] outdated [--depth]
+eask [GLOBAL-OPTIONS] outdated [--depth]
 ```
 
 ## 🔍 eask refresh
@@ -457,7 +457,7 @@ $ eask [GLOBAL-OPTIONS] outdated [--depth]
 Download package archives.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] refresh
+eask [GLOBAL-OPTIONS] refresh
 ```
 
 # 🚩 Generating
@@ -471,7 +471,7 @@ Generate autoload file.
 Write a package autoloads to `project-autoloads.el` in the project root.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate autoloads
+eask [GLOBAL-OPTIONS] generate autoloads
 ```
 
 `project` is the project name, as declared in `Eask`-file. See
@@ -487,7 +487,7 @@ Write a package descriptor file to `project-pkg.el` in the project root.
 Alias: `pkg`, `pkg-el`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate pkg-file
+eask [GLOBAL-OPTIONS] generate pkg-file
 ```
 
 `project` is the project name, as declared in `Eask`-file. See
@@ -499,7 +499,7 @@ for details.
 Generate recipe file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate recipe [DESTINATION]
+eask [GLOBAL-OPTIONS] generate recipe [DESTINATION]
 ```
 
 If [DESTINATION] is not specified, it will generate to the `/recipes` folder
@@ -510,7 +510,7 @@ by default.
 Generate LICENSE file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate license <name>
+eask [GLOBAL-OPTIONS] generate license <name>
 ```
 
 `name` is the type of the license, see https://api.github.com/licenses for all
@@ -526,7 +526,7 @@ to generate ignore file.
 Generate ignore file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate ignore <name>
+eask [GLOBAL-OPTIONS] generate ignore <name>
 ```
 
 {{< hint info >}}
@@ -539,7 +539,7 @@ to generate ignore file.
 Create a new test project for the [ert][] tests.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test ert [NAMES..]
+eask [GLOBAL-OPTIONS] generate test ert [NAMES..]
 ```
 
 ## 🔍 eask generate test ert-runner
@@ -547,7 +547,7 @@ $ eask [GLOBAL-OPTIONS] generate test ert [NAMES..]
 Create a new test project for the [ert-runner][].
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test ert-runner [NAMES..]
+eask [GLOBAL-OPTIONS] generate test ert-runner [NAMES..]
 ```
 
 ## 🔍 eask generate test buttercup
@@ -555,7 +555,7 @@ $ eask [GLOBAL-OPTIONS] generate test ert-runner [NAMES..]
 Create a new [Buttercup][] setup for the project.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test buttercup
+eask [GLOBAL-OPTIONS] generate test buttercup
 ```
 
 ## 🔍 eask generate test ecukes
@@ -563,7 +563,7 @@ $ eask [GLOBAL-OPTIONS] generate test buttercup
 Create a new [Ecukes][] setup for the project.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test ecukes
+eask [GLOBAL-OPTIONS] generate test ecukes
 ```
 
 ## 🔍 eask generate workflow circle-ci
@@ -573,7 +573,7 @@ Generate [CircleCI][] workflow yaml file.
 The default filename is `config.yml`.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow circle-ci [--file]
+eask [GLOBAL-OPTIONS] generate workflow circle-ci [--file]
 ```
 
 This will generate the yaml file under `.circleci/`!
@@ -585,7 +585,7 @@ Generate [GitHub Actions][] workflow yaml file.
 The default filename is `test.yml`.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow github [--file]
+eask [GLOBAL-OPTIONS] generate workflow github [--file]
 ```
 
 This will generate the yaml file under `.github/workflow/`!
@@ -597,7 +597,7 @@ Generate [GitLab Runner][] workflow yaml file.
 The default filename is `.gitlab-ci.yml`.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow gitlab [--file]
+eask [GLOBAL-OPTIONS] generate workflow gitlab [--file]
 ```
 
 ## 🔍 eask generate workflow travis-ci
@@ -607,7 +607,7 @@ Generate [Travis CI][] workflow yaml file.
 The default filename is `.travis.yml`.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow travis-ci [--file]
+eask [GLOBAL-OPTIONS] generate workflow travis-ci [--file]
 ```
 
 # 🚩 Linking
@@ -622,7 +622,7 @@ Links the given *source* directory into the package directory of this project,
 under the given *package* name.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] link add <NAME> <PATH>
+eask [GLOBAL-OPTIONS] link add <NAME> <PATH>
 ```
 
 ## 🔍 eask link delete
@@ -632,7 +632,7 @@ Deletes the link for the given packages.
 Alias: `remove`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] link delete [NAMES..]
+eask [GLOBAL-OPTIONS] link delete [NAMES..]
 ```
 
 ## 🔍 eask link list
@@ -640,7 +640,7 @@ $ eask [GLOBAL-OPTIONS] link delete [NAMES..]
 List all links.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] link list
+eask [GLOBAL-OPTIONS] link list
 ```
 
 # 🚩 Cleaning
@@ -654,13 +654,13 @@ Delete `.eask` from the current workspace.
 Alias: `.eask`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean workspace
+eask [GLOBAL-OPTIONS] clean workspace
 ```
 
 ⛔️ Don't specify the option `--config, -c`, or else it will delete your entire `~/.emacs.d`.
 
 ```elisp
-$ eask clean workspace -g
+eask clean workspace -g
 ```
 
 ## 🔍 eask clean elc
@@ -668,7 +668,7 @@ $ eask clean workspace -g
 Delete all `.elc` files. This would respect to your `Eask` file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean elc
+eask [GLOBAL-OPTIONS] clean elc
 ```
 
 ## 🔍 eask clean dist
@@ -678,7 +678,7 @@ Delete dist subdirectory.
 Alias: `distribution`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean dist
+eask [GLOBAL-OPTIONS] clean dist
 ```
 
 ## 🔍 eask clean autoloads
@@ -686,7 +686,7 @@ $ eask [GLOBAL-OPTIONS] clean dist
 Remove generated autoloads file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean autoloads
+eask [GLOBAL-OPTIONS] clean autoloads
 ```
 
 ## 🔍 eask clean pkg-file
@@ -694,7 +694,7 @@ $ eask [GLOBAL-OPTIONS] clean autoloads
 Remove generated pkg-file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean pkg-file
+eask [GLOBAL-OPTIONS] clean pkg-file
 ```
 
 ## 🔍 eask clean log-file
@@ -702,7 +702,7 @@ $ eask [GLOBAL-OPTIONS] clean pkg-file
 Remove all generated log files.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean log-file
+eask [GLOBAL-OPTIONS] clean log-file
 ```
 
 ## 🔍 eask clean all
@@ -719,7 +719,7 @@ This command is the combination of all other clean commands.
 Alias: `everything`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean all
+eask [GLOBAL-OPTIONS] clean all
 ```
 
 # 🚩 Linting
@@ -731,7 +731,7 @@ Commands that lint your Emacs package.
 Run [package-lint](https://github.com/purcell/package-lint).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint package [FILES..]
+eask [GLOBAL-OPTIONS] lint package [FILES..]
 ```
 
 ## 🔍 eask lint checkdoc
@@ -739,7 +739,7 @@ $ eask [GLOBAL-OPTIONS] lint package [FILES..]
 Run checkdoc (built-in).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint checkdoc [FILES..]
+eask [GLOBAL-OPTIONS] lint checkdoc [FILES..]
 ```
 
 ## 🔍 eask lint elint
@@ -747,7 +747,7 @@ $ eask [GLOBAL-OPTIONS] lint checkdoc [FILES..]
 Run elint (built-in).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint elint [FILES..]
+eask [GLOBAL-OPTIONS] lint elint [FILES..]
 ```
 
 ## 🔍 eask lint elisp-lint
@@ -755,7 +755,7 @@ $ eask [GLOBAL-OPTIONS] lint elint [FILES..]
 Run [elisp-lint](https://github.com/gonewest818/elisp-lint).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint elisp-lint [FILES..]
+eask [GLOBAL-OPTIONS] lint elisp-lint [FILES..]
 ```
 
 This does respect the `.dir-locals.el` file! 🎉
@@ -765,7 +765,7 @@ This does respect the `.dir-locals.el` file! 🎉
 Run [elsa](https://github.com/emacs-elsa/Elsa).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint lint elsa [FILES..]
+eask [GLOBAL-OPTIONS] lint lint elsa [FILES..]
 ```
 
 ## 🔍 eask lint indent
@@ -773,7 +773,7 @@ $ eask [GLOBAL-OPTIONS] lint lint elsa [FILES..]
 Run indent-lint.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint indent [FILES..]
+eask [GLOBAL-OPTIONS] lint indent [FILES..]
 ```
 
 ## 🔍 eask lint keywords
@@ -781,7 +781,7 @@ $ eask [GLOBAL-OPTIONS] lint indent [FILES..]
 Run keywords checker (built-in).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint keywords
+eask [GLOBAL-OPTIONS] lint keywords
 ```
 
 ## 🔍 eask lint license
@@ -789,7 +789,7 @@ $ eask [GLOBAL-OPTIONS] lint keywords
 Run license check.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint license
+eask [GLOBAL-OPTIONS] lint license
 ```
 
 ## 🔍 eask lint declare
@@ -797,7 +797,7 @@ $ eask [GLOBAL-OPTIONS] lint license
 Run check-declare (built-in).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint declare [FILES..]
+eask [GLOBAL-OPTIONS] lint declare [FILES..]
 ```
 
 ## 🔍 eask lint regexps
@@ -807,7 +807,7 @@ Run [relint](https://github.com/mattiase/relint).
 Alias: `lint relint`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint regexps [FILES..]
+eask [GLOBAL-OPTIONS] lint regexps [FILES..]
 ```
 
 # 🚩 Testing
@@ -819,7 +819,7 @@ Run regression/unit tests.
 Activate package; use to test the package activation
 
 ```sh
-$ eask [GLOBAL-OPTIONS] activate [FILES..]
+eask [GLOBAL-OPTIONS] activate [FILES..]
 ```
 
 {{< hint info >}}
@@ -833,7 +833,7 @@ $ eask [GLOBAL-OPTIONS] activate [FILES..]
 Run [ert][] tests.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test ert [FILES..]
+eask [GLOBAL-OPTIONS] test ert [FILES..]
 ```
 
 ## 🔍 eask test ert-runner
@@ -841,7 +841,7 @@ $ eask [GLOBAL-OPTIONS] test ert [FILES..]
 Run [ert][] test using [ert-runner][].
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test ert-runner
+eask [GLOBAL-OPTIONS] test ert-runner
 ```
 
 ## 🔍 eask test buttercup
@@ -849,7 +849,7 @@ $ eask [GLOBAL-OPTIONS] test ert-runner
 Run [buttercup][] tests.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test buttercup
+eask [GLOBAL-OPTIONS] test buttercup
 ```
 
 ## 🔍 eask test ecukes
@@ -857,7 +857,7 @@ $ eask [GLOBAL-OPTIONS] test buttercup
 Run [ecukes][] tests.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test ecukes [FILES..]
+eask [GLOBAL-OPTIONS] test ecukes [FILES..]
 ```
 
 ## 🔍 eask test melpazoid
@@ -865,7 +865,7 @@ $ eask [GLOBAL-OPTIONS] test ecukes [FILES..]
 Run [melpazoid][] tests.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test melpazoid [DIRECTORIES..]
+eask [GLOBAL-OPTIONS] test melpazoid [DIRECTORIES..]
 ```
 
 {{< hint info >}}
@@ -881,7 +881,7 @@ Commands that formats your Emacs source files.
 Run [elisp-autofmt][] formatter.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] format elisp-autofmt [FILES..]
+eask [GLOBAL-OPTIONS] format elisp-autofmt [FILES..]
 ```
 
 ## 🔍 eask format elfmt
@@ -889,7 +889,7 @@ $ eask [GLOBAL-OPTIONS] format elisp-autofmt [FILES..]
 Run [elfmt][] formatter.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] format elfmt [FILES..]
+eask [GLOBAL-OPTIONS] format elfmt [FILES..]
 ```
 
 # 🚩 Control DSL
@@ -901,7 +901,7 @@ List of commands that control DSL.
 Add an archive source.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] source add <NAME> [URL]
+eask [GLOBAL-OPTIONS] source add <NAME> [URL]
 ```
 
 ## 🔍 eask source delete
@@ -911,7 +911,7 @@ Remove an archive source.
 Alias: `remove`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] source delete <NAME>
+eask [GLOBAL-OPTIONS] source delete <NAME>
 ```
 
 ## 🔍 eask source list
@@ -919,11 +919,11 @@ $ eask [GLOBAL-OPTIONS] source delete <NAME>
 List all source information.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] source list
+eask [GLOBAL-OPTIONS] source list
 ```
 
 {{< hint info >}}
-💡 This command is the same as `$ eask archives`!
+💡 This command is the same as `eask archives`!
 {{< /hint >}}
 
 # 🚩 Utilities
@@ -937,7 +937,7 @@ Upgrade Eask to the latest version.
 Alias: `upgrade-self`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] upgrade-eask
+eask [GLOBAL-OPTIONS] upgrade-eask
 ```
 
 {{< hint warning >}}
@@ -949,7 +949,7 @@ $ eask [GLOBAL-OPTIONS] upgrade-eask
 Show Eask installed location.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] locate
+eask [GLOBAL-OPTIONS] locate
 ```
 
 # 🚩 Checker
@@ -961,7 +961,7 @@ Commands to check your Eask-file.
 Lint an `Eask`-file.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] analyze [FILES..]
+eask [GLOBAL-OPTIONS] analyze [FILES..]
 ```
 
 Example:
@@ -990,7 +990,7 @@ This will use `~/.eask/` instead of the package development environment.
 This is used for other tasks. e.g., `cat`, etc.
 
 ```sh
-$ eask -g [COMMAND]
+eask -g [COMMAND]
 ```
 
 ## 🔍 --config, -c
@@ -1001,7 +1001,7 @@ This is used for doing stuff for your **Emacs configuration**. e.g., package
 management, etc.
 
 ```sh
-$ eask -c [COMMAND]
+eask -c [COMMAND]
 ```
 
 ## 🔍 --all, -a
@@ -1009,7 +1009,7 @@ $ eask -c [COMMAND]
 Enable the `all` flag.
 
 ```sh
-$ eask -a [COMMAND]
+eask -a [COMMAND]
 ```
 
 ## 🔍 --quick, -q
@@ -1017,7 +1017,7 @@ $ eask -a [COMMAND]
 Start cleanly without loading the configuration files.
 
 ```sh
-$ eask -q [COMMAND]
+eask -q [COMMAND]
 ```
 
 ## 🔍 --force, -f
@@ -1027,7 +1027,7 @@ Force command's execution.
 Force to uninstall the package `dash` even it's a dependency from another packages.
 
 ```sh
-$ eask -f [COMMAND]
+eask -f [COMMAND]
 ```
 
 ## 🔍 --debug
@@ -1083,7 +1083,7 @@ Show elapsed time between each operation.
 Set verbosity from 0 to 5.
 
 ```sh
-$ eask --verbose 4 [COMMAND]
+eask --verbose 4 [COMMAND]
 ```
 
 ## 🔍 --version
@@ -1101,7 +1101,7 @@ Show help.
 Set Emacs proxy for HTTP and HTTPS:
 
 ```sh
-$ eask --proxy "localhost:8888" [COMMAND]
+eask --proxy "localhost:8888" [COMMAND]
 ```
 
 ## 🔍 --http-proxy `<proxy>`

--- a/docs/content/Getting-Started/Commands-and-options/_index.zh-tw.md
+++ b/docs/content/Getting-Started/Commands-and-options/_index.zh-tw.md
@@ -8,7 +8,7 @@ weight: 300
 **eask** 程序的一般語法是：
 
 ```sh
-$ eask [GLOBAL-OPTIONS] [COMMAND] [COMMAND-OPTIONS] [COMMAND-ARGUMENTS]
+eask [GLOBAL-OPTIONS] [COMMAND] [COMMAND-OPTIONS] [COMMAND-ARGUMENTS]
 ```
 
 # 🚩 創建
@@ -18,7 +18,7 @@ $ eask [GLOBAL-OPTIONS] [COMMAND] [COMMAND-OPTIONS] [COMMAND-ARGUMENTS]
 使用默認的 `Eask` 文件和 CI/CD 支持創建一個新的 elisp 項目。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] create package <name>
+eask [GLOBAL-OPTIONS] create package <name>
 ```
 
 {{< hint info >}}
@@ -30,7 +30,7 @@ $ eask [GLOBAL-OPTIONS] create package <name>
 使用 [github-elpa](https://github.com/10sr/github-elpa) 創建一個新的 ELPA。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] create elpa <name>
+eask [GLOBAL-OPTIONS] create elpa <name>
 ```
 
 {{< hint info >}}
@@ -46,7 +46,7 @@ $ eask [GLOBAL-OPTIONS] create elpa <name>
 初始化當前目錄以開始使用 Eask。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] init
+eask [GLOBAL-OPTIONS] init
 ```
 
 Eask 將生成這樣的文件：
@@ -71,25 +71,25 @@ Eask 將生成這樣的文件：
 **[推薦]** 如果您已有 elisp 項目，您可以將 `.el` 文件轉換為 Eask 文件：
 
 ```
-$ eask init --from source /path/to/source.el
+eask init --from source /path/to/source.el
 ```
 
 如果您已有 [Cask][] 項目，您可以將 Cask 文件轉換為 Eask 文件：
 
 ```
-$ eask init --from cask /path/to/Cask
+eask init --from cask /path/to/Cask
 ```
 
 如果您已有 [Eldev][] 項目，您可以將 Eldev 文件轉換為 Eask 文件：
 
 ```
-$ eask init --from eldev /path/to/Eldev
+eask init --from eldev /path/to/Eldev
 ```
 
 如果您已有 [Keg][] 項目，您可以將 Keg 文件轉換為 Eask 文件：
 
 ```
-$ eask init --from keg /path/to/Keg
+eask init --from keg /path/to/Keg
 ```
 
 {{< hint ok >}}
@@ -101,7 +101,7 @@ $ eask init --from keg /path/to/Keg
 顯示有關項目或配置的信息。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] info
+eask [GLOBAL-OPTIONS] info
 ```
 
 ## 🔍 eask status
@@ -109,7 +109,7 @@ $ eask [GLOBAL-OPTIONS] info
 顯示工作區的狀態。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] status
+eask [GLOBAL-OPTIONS] status
 ```
 
 ## 🔍 eask install-deps
@@ -119,7 +119,7 @@ $ eask [GLOBAL-OPTIONS] status
 別名: `install-dependencies`, `prepare`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] install-deps [--dev]
+eask [GLOBAL-OPTIONS] install-deps [--dev]
 ```
 
 {{< hint ok >}}
@@ -131,19 +131,19 @@ $ eask [GLOBAL-OPTIONS] install-deps [--dev]
 安裝軟件包。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] install [PACKAGES..]
+eask [GLOBAL-OPTIONS] install [PACKAGES..]
 ```
 
 通過指定參數安裝包：
 
 ```sh
-$ eask install auto-complete helm magit
+eask install auto-complete helm magit
 ```
 
 否則，它將安裝當前開發的包：
 
 ```sh
-$ eask install
+eask install
 ```
 
 ## 🔍 eask uninstall
@@ -151,19 +151,19 @@ $ eask install
 卸載/刪除包。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] uninstall [PACKAGES..]
+eask [GLOBAL-OPTIONS] uninstall [PACKAGES..]
 ```
 
 通過指定參數卸載軟件包：
 
 ```sh
-$ eask uninstall dash f s
+eask uninstall dash f s
 ```
 
 否則，它將從當前開發中卸載包：
 
 ```sh
-$ eask uninstall
+eask uninstall
 ```
 
 ## 🔍 eask package
@@ -173,7 +173,7 @@ $ eask uninstall
 別名: `pack`
 
 ```sh
-$ eask package [DESTINATION]
+eask package [DESTINATION]
 ```
 
 如果未指定 [DESTINATION]，則默認導出到 `/dist` 文件夾。
@@ -183,19 +183,19 @@ $ eask package [DESTINATION]
 字節編譯 `.el` 文件。
 
 ```sh
-$ eask compile [FILES..]
+eask compile [FILES..]
 ```
 
 通過指定參數編譯文件：
 
 ```sh
-$ eask compile file-1.el file-2.el
+eask compile file-1.el file-2.el
 ```
 
 或者編譯已經在你的 `Eask` 文件中指定的文件。
 
 ```sh
-$ eask compile
+eask compile
 ```
 
 ## 🔍 eask recompile
@@ -203,7 +203,7 @@ $ eask compile
 重新字節編譯 `.el` 文件。
 
 ```sh
-$ eask recompile [FILES..]
+eask recompile [FILES..]
 ```
 
 {{< hint info >}}
@@ -215,7 +215,7 @@ $ eask recompile [FILES..]
 打印包目錄的路徑，其中安裝了所有依賴項。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] package-directory
+eask [GLOBAL-OPTIONS] package-directory
 ```
 
 ## 🔍 eask path
@@ -225,7 +225,7 @@ $ eask [GLOBAL-OPTIONS] package-directory
 別名: `exec-path`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] path [PATTERNS..]
+eask [GLOBAL-OPTIONS] path [PATTERNS..]
 ```
 
 或者，您可以傳入 `[PATTERNS..]` 來執行搜索。
@@ -235,7 +235,7 @@ $ eask [GLOBAL-OPTIONS] path [PATTERNS..]
 打印包含當前項目依賴項的加載路徑。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] load-path [PATTERNS..]
+eask [GLOBAL-OPTIONS] load-path [PATTERNS..]
 ```
 
 或者，您可以傳入 `[PATTERNS..]` 來執行搜索。
@@ -245,7 +245,7 @@ $ eask [GLOBAL-OPTIONS] load-path [PATTERNS..]
 打印所有包文件的列表。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] files [PATTERNS..]
+eask [GLOBAL-OPTIONS] files [PATTERNS..]
 ```
 
 如果定義了 `[PATTERNS..]` ，它將顯示與該模式匹配的文件。
@@ -255,7 +255,7 @@ $ eask [GLOBAL-OPTIONS] files [PATTERNS..]
 建議 recipe 格式。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] recipe [FILES..]
+eask [GLOBAL-OPTIONS] recipe [FILES..]
 ```
 
 ## 🔍 eask keywords
@@ -263,7 +263,7 @@ $ eask [GLOBAL-OPTIONS] recipe [FILES..]
 列出可在標題部分中使用的可用關鍵字。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] keywords
+eask [GLOBAL-OPTIONS] keywords
 ```
 
 ## 🔍 eask bump
@@ -271,7 +271,7 @@ $ eask [GLOBAL-OPTIONS] keywords
 為你的專案或 Eask-file 遞增版本號。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] bump [LEVELS..]
+eask [GLOBAL-OPTIONS] bump [LEVELS..]
 ```
 
 {{< hint info >}}
@@ -285,7 +285,7 @@ $ eask [GLOBAL-OPTIONS] bump [LEVELS..]
 位置參數 `[PATTERNS..]` 是一個通配符模式數組。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] cat [PATTERNS..]
+eask [GLOBAL-OPTIONS] cat [PATTERNS..]
 ```
 
 {{< hint info >}}
@@ -297,7 +297,7 @@ $ eask [GLOBAL-OPTIONS] cat [PATTERNS..]
 將所有 Emacs Lisp 文件連接成一個文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] concat [FILES..]
+eask [GLOBAL-OPTIONS] concat [FILES..]
 ```
 
 ## 🔍 eask loc
@@ -305,7 +305,7 @@ $ eask [GLOBAL-OPTIONS] concat [FILES..]
 列印 LOC 信息。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] loc [FILES..]
+eask [GLOBAL-OPTIONS] loc [FILES..]
 ```
 
 # 🚩 文件
@@ -317,7 +317,7 @@ $ eask [GLOBAL-OPTIONS] loc [FILES..]
 建置文檔。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] docs [NAMES..]
+eask [GLOBAL-OPTIONS] docs [NAMES..]
 ```
 
 # 🚩 執行
@@ -331,7 +331,7 @@ $ eask [GLOBAL-OPTIONS] docs [NAMES..]
 按順序加載 Emacs Lisp 文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] load [FILES..]
+eask [GLOBAL-OPTIONS] load [FILES..]
 ```
 
 ## 🔍 eask exec
@@ -339,7 +339,7 @@ $ eask [GLOBAL-OPTIONS] load [FILES..]
 使用給定的參數執行系統命令。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] exec [COMMAND] [ARGUMENTS ...]
+eask [GLOBAL-OPTIONS] exec [COMMAND] [ARGUMENTS ...]
 ```
 
 ## 🔍 eask emacs
@@ -347,7 +347,7 @@ $ eask [GLOBAL-OPTIONS] exec [COMMAND] [ARGUMENTS ...]
 在合適的環境下執行emacs。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
+eask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
 ```
 
 ## 🔍 eask eval
@@ -355,7 +355,7 @@ $ eask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
 將 `FORM` 評估為 lisp 形式。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] eval [FORM]
+eask [GLOBAL-OPTIONS] eval [FORM]
 ```
 
 ## 🔍 eask repl
@@ -363,7 +363,7 @@ $ eask [GLOBAL-OPTIONS] eval [FORM]
 啟動 Elisp REPL。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] repl [FILES..]
+eask [GLOBAL-OPTIONS] repl [FILES..]
 ```
 
 別名: `ielm`
@@ -373,7 +373,7 @@ $ eask [GLOBAL-OPTIONS] repl [FILES..]
 運行腳本。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] run script [NAMES..]
+eask [GLOBAL-OPTIONS] run script [NAMES..]
 ```
 
 ## 🔍 eask run command
@@ -383,7 +383,7 @@ $ eask [GLOBAL-OPTIONS] run script [NAMES..]
 別名: `cmd`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] run command [NAMES..]
+eask [GLOBAL-OPTIONS] run command [NAMES..]
 ```
 
 ## 🔍 eask docker
@@ -391,13 +391,13 @@ $ eask [GLOBAL-OPTIONS] run command [NAMES..]
 在 Docker 容器中啟動指定的 Emacs 版本
 
 ```sh
-$ eask [GLOBAL-OPTIONS] docker <VERSION> [ARGUMENTS ...]
+eask [GLOBAL-OPTIONS] docker <VERSION> [ARGUMENTS ...]
 ```
 
 例如：
 
 ```sh
-$ eask docker 26.1 info
+eask docker 26.1 info
 ```
 
 這與直接跳入 Emacs 26.1（在 docker 中）並執行 `eask info` 相同。
@@ -411,7 +411,7 @@ $ eask docker 26.1 info
 列出所有包源。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] archives
+eask [GLOBAL-OPTIONS] archives
 ```
 
 ## 🔍 eask search
@@ -419,7 +419,7 @@ $ eask [GLOBAL-OPTIONS] archives
 從包源中搜索包。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] search [QUEIRES..]
+eask [GLOBAL-OPTIONS] search [QUEIRES..]
 ```
 
 ## 🔍 eask upgrade
@@ -427,7 +427,7 @@ $ eask [GLOBAL-OPTIONS] search [QUEIRES..]
 升級所有軟件包。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] upgrade
+eask [GLOBAL-OPTIONS] upgrade
 ```
 
 ## 🔍 eask list
@@ -435,7 +435,7 @@ $ eask [GLOBAL-OPTIONS] upgrade
 列出包。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] list [--depth]
+eask [GLOBAL-OPTIONS] list [--depth]
 ```
 
 ## 🔍 eask outdated
@@ -443,7 +443,7 @@ $ eask [GLOBAL-OPTIONS] list [--depth]
 列出所有過時的包。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] outdated [--depth]
+eask [GLOBAL-OPTIONS] outdated [--depth]
 ```
 
 ## 🔍 eask refresh
@@ -451,7 +451,7 @@ $ eask [GLOBAL-OPTIONS] outdated [--depth]
 刷新包源。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] refresh
+eask [GLOBAL-OPTIONS] refresh
 ```
 
 # 🚩 生成
@@ -465,7 +465,7 @@ $ eask [GLOBAL-OPTIONS] refresh
 將包自動加載到項目根目錄中的 `project-autoloads.el`。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate autoloads
+eask [GLOBAL-OPTIONS] generate autoloads
 ```
 
 `project` 是在 `Eask` 文件中聲明的項目名稱。 有關詳細信息，請參閱
@@ -480,7 +480,7 @@ $ eask [GLOBAL-OPTIONS] generate autoloads
 別名: `pkg`, `pkg-el`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate pkg-file
+eask [GLOBAL-OPTIONS] generate pkg-file
 ```
 
 `project` 是在 `Eask` 文件中聲明的項目名稱。 有關詳細信息，請參閱
@@ -491,7 +491,7 @@ $ eask [GLOBAL-OPTIONS] generate pkg-file
 生成 recipe 文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate recipe [DESTINATION]
+eask [GLOBAL-OPTIONS] generate recipe [DESTINATION]
 ```
 
 如果未指定 [DESTINATION]，則默認導出到 `/recipes` 文件夾。
@@ -501,7 +501,7 @@ $ eask [GLOBAL-OPTIONS] generate recipe [DESTINATION]
 生成 LICENSE 文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate license <name>
+eask [GLOBAL-OPTIONS] generate license <name>
 ```
 
 name` 是許可證的類型，請參閱 https://api.github.com/licenses 了解所有選擇。
@@ -515,7 +515,7 @@ name` 是許可證的類型，請參閱 https://api.github.com/licenses 了解�
 生成忽略文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate ignore <name>
+eask [GLOBAL-OPTIONS] generate ignore <name>
 ```
 
 {{< hint info >}}
@@ -527,7 +527,7 @@ $ eask [GLOBAL-OPTIONS] generate ignore <name>
 為 [ert][]測試建立一個新的測試項目。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test ert [NAMES..]
+eask [GLOBAL-OPTIONS] generate test ert [NAMES..]
 ```
 
 ## 🔍 eask generate test ert-runner
@@ -535,7 +535,7 @@ $ eask [GLOBAL-OPTIONS] generate test ert [NAMES..]
 為 [ert-runner][] 建立一個新的測試項目。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test ert-runner [NAMES..]
+eask [GLOBAL-OPTIONS] generate test ert-runner [NAMES..]
 ```
 
 ## 🔍 eask generate test buttercup
@@ -543,7 +543,7 @@ $ eask [GLOBAL-OPTIONS] generate test ert-runner [NAMES..]
 為專案建立一個新的 [Buttercup][] 設定。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test buttercup
+eask [GLOBAL-OPTIONS] generate test buttercup
 ```
 
 ## 🔍 eask generate test ecukes
@@ -551,7 +551,7 @@ $ eask [GLOBAL-OPTIONS] generate test buttercup
 為專案創建一個新的 [Ecukes][] 設定。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate test ecukes
+eask [GLOBAL-OPTIONS] generate test ecukes
 ```
 
 ## 🔍 eask generate workflow circle-ci
@@ -561,7 +561,7 @@ $ eask [GLOBAL-OPTIONS] generate test ecukes
 默認文件名為 `config.yml`。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow circle-ci [--file]
+eask [GLOBAL-OPTIONS] generate workflow circle-ci [--file]
 ```
 
 這將在 `.circleci/` 下生成 yaml 文件！
@@ -573,7 +573,7 @@ $ eask [GLOBAL-OPTIONS] generate workflow circle-ci [--file]
 默認文件名為 `test.yml`。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow github [--file]
+eask [GLOBAL-OPTIONS] generate workflow github [--file]
 ```
 
 這將在 `.github/workflow/` 下生成 yaml 文件！
@@ -585,7 +585,7 @@ $ eask [GLOBAL-OPTIONS] generate workflow github [--file]
 默認文件名為 `.gitlab-ci.yml`。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow gitlab [--file]
+eask [GLOBAL-OPTIONS] generate workflow gitlab [--file]
 ```
 
 ## 🔍 eask generate workflow travis-ci
@@ -595,7 +595,7 @@ $ eask [GLOBAL-OPTIONS] generate workflow gitlab [--file]
 默認文件名為 `.travis.yml`。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] generate workflow travis-ci [--file]
+eask [GLOBAL-OPTIONS] generate workflow travis-ci [--file]
 ```
 
 # 🚩 連結
@@ -608,7 +608,7 @@ $ eask [GLOBAL-OPTIONS] generate workflow travis-ci [--file]
 將給定的 *source* 目錄鏈接到此項目的包目錄，在給定的 *package* 名稱下。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] link add <NAME> <PATH>
+eask [GLOBAL-OPTIONS] link add <NAME> <PATH>
 ```
 
 ## 🔍 eask link delete
@@ -618,7 +618,7 @@ $ eask [GLOBAL-OPTIONS] link add <NAME> <PATH>
 別名: `remove`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] link delete [NAMES..]
+eask [GLOBAL-OPTIONS] link delete [NAMES..]
 ```
 
 ## 🔍 eask link list
@@ -626,7 +626,7 @@ $ eask [GLOBAL-OPTIONS] link delete [NAMES..]
 列出所有鏈接。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] link list
+eask [GLOBAL-OPTIONS] link list
 ```
 
 # 🚩 清理
@@ -640,13 +640,13 @@ $ eask [GLOBAL-OPTIONS] link list
 別名: `.eask`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean workspace
+eask [GLOBAL-OPTIONS] clean workspace
 ```
 
 ⛔️ 不要指定選項 `--config, -c`，否則它會刪除你的整個 `~/.emacs.d`。
 
 ```elisp
-$ eask clean workspace -g
+eask clean workspace -g
 ```
 
 ## 🔍 eask clean elc
@@ -654,7 +654,7 @@ $ eask clean workspace -g
 刪除所有 `.elc` 文件。 這將尊重您的 `Eask` 文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean elc
+eask [GLOBAL-OPTIONS] clean elc
 ```
 
 ## 🔍 eask clean dist
@@ -664,7 +664,7 @@ $ eask [GLOBAL-OPTIONS] clean elc
 別名: `distribution`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean dist
+eask [GLOBAL-OPTIONS] clean dist
 ```
 
 ## 🔍 eask clean autoloads
@@ -672,7 +672,7 @@ $ eask [GLOBAL-OPTIONS] clean dist
 刪除生成的 autoload 文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean autoloads
+eask [GLOBAL-OPTIONS] clean autoloads
 ```
 
 ## 🔍 eask clean pkg-file
@@ -680,7 +680,7 @@ $ eask [GLOBAL-OPTIONS] clean autoloads
 刪除生成的 pkg 文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean pkg-file
+eask [GLOBAL-OPTIONS] clean pkg-file
 ```
 
 ## 🔍 eask clean log-file
@@ -688,7 +688,7 @@ $ eask [GLOBAL-OPTIONS] clean pkg-file
 刪除所有生成的日誌文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean log-file
+eask [GLOBAL-OPTIONS] clean log-file
 ```
 
 ## 🔍 eask clean all
@@ -705,7 +705,7 @@ $ eask [GLOBAL-OPTIONS] clean log-file
 別名: `everything`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] clean all
+eask [GLOBAL-OPTIONS] clean all
 ```
 
 # 🚩 检查
@@ -717,7 +717,7 @@ $ eask [GLOBAL-OPTIONS] clean all
 運行 [package-lint](https://github.com/purcell/package-lint).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint package [FILES..]
+eask [GLOBAL-OPTIONS] lint package [FILES..]
 ```
 
 ## 🔍 eask lint checkdoc
@@ -725,7 +725,7 @@ $ eask [GLOBAL-OPTIONS] lint package [FILES..]
 運行 checkdoc (自帶).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint checkdoc [FILES..]
+eask [GLOBAL-OPTIONS] lint checkdoc [FILES..]
 ```
 
 ## 🔍 eask lint elint
@@ -733,7 +733,7 @@ $ eask [GLOBAL-OPTIONS] lint checkdoc [FILES..]
 運行 elint (自帶).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint elint [FILES..]
+eask [GLOBAL-OPTIONS] lint elint [FILES..]
 ```
 
 ## 🔍 eask lint elisp-lint
@@ -741,7 +741,7 @@ $ eask [GLOBAL-OPTIONS] lint elint [FILES..]
 運行 [elisp-lint](https://github.com/gonewest818/elisp-lint).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint elisp-lint [FILES..]
+eask [GLOBAL-OPTIONS] lint elisp-lint [FILES..]
 ```
 
 這確實尊重 .dir-locals.el 文件！ 🎉
@@ -751,7 +751,7 @@ $ eask [GLOBAL-OPTIONS] lint elisp-lint [FILES..]
 運行 [elsa](https://github.com/emacs-elsa/Elsa).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint lint elsa [FILES..]
+eask [GLOBAL-OPTIONS] lint lint elsa [FILES..]
 ```
 
 ## 🔍 eask lint indent
@@ -759,7 +759,7 @@ $ eask [GLOBAL-OPTIONS] lint lint elsa [FILES..]
 運行 indent-lint.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint indent [FILES..]
+eask [GLOBAL-OPTIONS] lint indent [FILES..]
 ```
 
 ## 🔍 eask lint keywords
@@ -767,7 +767,7 @@ $ eask [GLOBAL-OPTIONS] lint indent [FILES..]
 運行 keywords checker (自帶).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint keywords
+eask [GLOBAL-OPTIONS] lint keywords
 ```
 
 ## 🔍 eask lint license
@@ -775,7 +775,7 @@ $ eask [GLOBAL-OPTIONS] lint keywords
 運行 license check.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint license
+eask [GLOBAL-OPTIONS] lint license
 ```
 
 ## 🔍 eask lint declare
@@ -783,7 +783,7 @@ $ eask [GLOBAL-OPTIONS] lint license
 運行 check-declare (自帶).
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint declare [FILES..]
+eask [GLOBAL-OPTIONS] lint declare [FILES..]
 ```
 
 ## 🔍 eask lint regexps
@@ -793,7 +793,7 @@ Run [relint](https://github.com/mattiase/relint).
 別名: `lint relint`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] lint regexps [FILES..]
+eask [GLOBAL-OPTIONS] lint regexps [FILES..]
 ```
 
 # 🚩 測試框架
@@ -805,7 +805,7 @@ $ eask [GLOBAL-OPTIONS] lint regexps [FILES..]
 激活包； 用於測試包激活
 
 ```sh
-$ eask [GLOBAL-OPTIONS] activate [FILES..]
+eask [GLOBAL-OPTIONS] activate [FILES..]
 ```
 
 {{< hint info >}}
@@ -819,7 +819,7 @@ $ eask [GLOBAL-OPTIONS] activate [FILES..]
 運行 [ert][] 測試。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test ert [FILES..]
+eask [GLOBAL-OPTIONS] test ert [FILES..]
 ```
 
 ## 🔍 eask test ert-runner
@@ -827,7 +827,7 @@ $ eask [GLOBAL-OPTIONS] test ert [FILES..]
 使用 [ert-runner][] 運行 [ert][] 測試。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test ert-runner
+eask [GLOBAL-OPTIONS] test ert-runner
 ```
 
 ## 🔍 eask test buttercup
@@ -835,7 +835,7 @@ $ eask [GLOBAL-OPTIONS] test ert-runner
 運行 [buttercup][] 測試。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test buttercup
+eask [GLOBAL-OPTIONS] test buttercup
 ```
 
 ## 🔍 eask test ecukes
@@ -843,7 +843,7 @@ $ eask [GLOBAL-OPTIONS] test buttercup
 運行 [ecukes][] 測試。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test ecukes [FILES..]
+eask [GLOBAL-OPTIONS] test ecukes [FILES..]
 ```
 
 ## 🔍 eask test melpazoid
@@ -851,7 +851,7 @@ $ eask [GLOBAL-OPTIONS] test ecukes [FILES..]
 運行 [melpazoid][] 測試。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] test melpazoid [DIRECTORIES..]
+eask [GLOBAL-OPTIONS] test melpazoid [DIRECTORIES..]
 ```
 
 {{< hint info >}}
@@ -867,7 +867,7 @@ $ eask [GLOBAL-OPTIONS] test melpazoid [DIRECTORIES..]
 運行 [elisp-autofmt][] 格式器.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] format elisp-autofmt [FILES..]
+eask [GLOBAL-OPTIONS] format elisp-autofmt [FILES..]
 ```
 
 ## 🔍 eask format elfmt
@@ -875,7 +875,7 @@ $ eask [GLOBAL-OPTIONS] format elisp-autofmt [FILES..]
 運行 [elfmt][] 格式器.
 
 ```sh
-$ eask [GLOBAL-OPTIONS] format elfmt [FILES..]
+eask [GLOBAL-OPTIONS] format elfmt [FILES..]
 ```
 
 # 🚩 控制 DSL
@@ -887,7 +887,7 @@ $ eask [GLOBAL-OPTIONS] format elfmt [FILES..]
 新增一個包源。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] source add <NAME> [URL]
+eask [GLOBAL-OPTIONS] source add <NAME> [URL]
 ```
 
 ## 🔍 eask source delete
@@ -897,7 +897,7 @@ $ eask [GLOBAL-OPTIONS] source add <NAME> [URL]
 別名: `remove`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] source delete <NAME>
+eask [GLOBAL-OPTIONS] source delete <NAME>
 ```
 
 ## 🔍 eask source list
@@ -905,11 +905,11 @@ $ eask [GLOBAL-OPTIONS] source delete <NAME>
 列出所有包源。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] source list
+eask [GLOBAL-OPTIONS] source list
 ```
 
 {{< hint info >}}
-💡 指令與 `$ eask archives` 相同!
+💡 指令與 `eask archives` 相同!
 {{< /hint >}}
 
 # 🚩 實用工具
@@ -923,7 +923,7 @@ $ eask [GLOBAL-OPTIONS] source list
 別名: `upgrade-self`
 
 ```sh
-$ eask [GLOBAL-OPTIONS] upgrade-eask
+eask [GLOBAL-OPTIONS] upgrade-eask
 ```
 
 {{< hint warning >}}
@@ -935,7 +935,7 @@ $ eask [GLOBAL-OPTIONS] upgrade-eask
 顯示 Eask 安裝位置。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] locate
+eask [GLOBAL-OPTIONS] locate
 ```
 
 # 🚩 檢查器
@@ -947,7 +947,7 @@ $ eask [GLOBAL-OPTIONS] locate
 檢查 `Eask` 文件。
 
 ```sh
-$ eask [GLOBAL-OPTIONS] analyze [FILES..]
+eask [GLOBAL-OPTIONS] analyze [FILES..]
 ```
 
 例子:
@@ -976,7 +976,7 @@ eask analyze --json
 這用於其他任務。 例如，`cat` 等。
 
 ```sh
-$ eask -g [COMMAND]
+eask -g [COMMAND]
 ```
 
 ## 🔍 --config, -c
@@ -986,7 +986,7 @@ $ eask -g [COMMAND]
 這用於為您的**Emacs 配置**做一些事情。 例如，包管理等。
 
 ```sh
-$ eask -c [COMMAND]
+eask -c [COMMAND]
 ```
 
 ## 🔍 --all, -a
@@ -994,7 +994,7 @@ $ eask -c [COMMAND]
 啟用 `all` 標誌。
 
 ```sh
-$ eask -a [COMMAND]
+eask -a [COMMAND]
 ```
 
 ## 🔍 --quick, -q
@@ -1002,7 +1002,7 @@ $ eask -a [COMMAND]
 乾淨地啟動而不加載配置文件。
 
 ```sh
-$ eask -q [COMMAND]
+eask -q [COMMAND]
 ```
 
 ## 🔍 --force, -f
@@ -1012,7 +1012,7 @@ $ eask -q [COMMAND]
 強制卸載包 `dash` ，即使它是另一個包的依賴項
 
 ```sh
-$ eask -f [COMMAND]
+eask -f [COMMAND]
 ```
 
 ## 🔍 --debug
@@ -1068,7 +1068,7 @@ $ eask -f [COMMAND]
 將詳細程度從 0 設置為 5。
 
 ```sh
-$ eask --verbose 4 [COMMAND]
+eask --verbose 4 [COMMAND]
 ```
 
 ## 🔍 --version
@@ -1086,7 +1086,7 @@ $ eask --verbose 4 [COMMAND]
 為 HTTP 和 HTTPS 設置 Emacs 代理：
 
 ```sh
-$ eask --proxy "localhost:8888" [COMMAND]
+eask --proxy "localhost:8888" [COMMAND]
 ```
 
 ## 🔍 --http-proxy `<proxy>`

--- a/docs/content/Getting-Started/Finding-Emacs/_index.en.md
+++ b/docs/content/Getting-Started/Finding-Emacs/_index.en.md
@@ -8,14 +8,14 @@ the `emacs` command. To pick a different Emacs, set the environment variable
 `EMACS` to the command name or executable path of the Emacs to use:
 
 ```sh
-$ EMACS="emacs-26.1" eask command
+EMACS="emacs-26.1" eask command
 ```
 
 Note that installed dependencies are scoped on the version of Emacs. So when
 switching between versions you will have to install the dependencies for each:
 
 ```sh
-$ EMACS="emacs-26.3" eask install
+EMACS="emacs-26.3" eask install
 ```
 
 There are, unfortunately, circumstances under which Emacs itself resets the

--- a/docs/content/Getting-Started/Finding-Emacs/_index.zh-tw.md
+++ b/docs/content/Getting-Started/Finding-Emacs/_index.zh-tw.md
@@ -7,13 +7,13 @@ weight: 150
 Emacs，請將環境變量 `EMACS` 設置為要使用的 `Emacs` 的命令名稱或可執行路徑：
 
 ```sh
-$ EMACS="emacs-26.1" eask command
+EMACS="emacs-26.1" eask command
 ```
 
 請注意，已安裝的依賴項受 Emacs 版本的影響。 因此，在版本之間切換時，您必須為每個版本安裝依賴項：
 
 ```sh
-$ EMACS="emacs-26.3" eask install
+EMACS="emacs-26.3" eask install
 ```
 
 不幸的是，在某些情況下，Emacs 本身會以與 **eask** 衝突的方式重置 `EMACS` 變量，在這種情況下，

--- a/docs/content/Getting-Started/Install-Eask/_index.en.md
+++ b/docs/content/Getting-Started/Install-Eask/_index.en.md
@@ -24,13 +24,13 @@ is the most probable location.
 On macOS or Linux:
 
 ```sh
-$ curl -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.sh | sh
 ```
 
 On Windows:
 
 ```sh
-$ curl.exe -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.bat | cmd /Q
+curl.exe -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.bat | cmd /Q
 ```
 
 ## 💾 Package managers
@@ -41,7 +41,7 @@ If you have [npm][] installed on your machine, you can
 install Eask with the following one-liner:
 
 ```sh
-$ npm install -g @emacs-eask/cli
+npm install -g @emacs-eask/cli
 ```
 
 ### 📦 Nix (macOS or Linux)
@@ -50,7 +50,7 @@ $ npm install -g @emacs-eask/cli
 To install the Eask CLI:
 
 ```sh
-$ nix profile install nixpkgs#eask-cli
+nix profile install nixpkgs#eask-cli
 ```
 
 ### 📦 Homebrew (macOS or Linux)
@@ -59,8 +59,8 @@ $ nix profile install nixpkgs#eask-cli
 To install the Eask CLI:
 
 ```sh
-$ brew tap emacs-eask/cli https://github.com/emacs-eask/packaging
-$ brew install eask-cli
+brew tap emacs-eask/cli https://github.com/emacs-eask/packaging
+brew install eask-cli
 ```
 
 ### 📦 MacPorts (macOS)
@@ -69,7 +69,7 @@ $ brew install eask-cli
 To install the Eask CLI:
 
 ```sh
-$ sudo port install eask-cli
+sudo port install eask-cli
 ```
 
 ### 📦 Debian (Linux)
@@ -79,10 +79,10 @@ Derivatives of the [Debian][] distribution of Linux include [elementary OS][],
 [Ubuntu][], [Zorin OS][], and others.
 
 ```sh
-$ sudo curl -SsL -o /etc/apt/trusted.gpg.d/easksource.gpg https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/KEY.gpg
-$ sudo curl -SsL -o /etc/apt/sources.list.d/easksource.list https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/easksource.list
-$ sudo apt update --allow-insecure-repositories
-$ sudo apt install eask-cli --allow-unauthenticated
+sudo curl -SsL -o /etc/apt/trusted.gpg.d/easksource.gpg https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/KEY.gpg
+sudo curl -SsL -o /etc/apt/sources.list.d/easksource.list https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/easksource.list
+sudo apt update --allow-insecure-repositories
+sudo apt install eask-cli --allow-unauthenticated
 ```
 
 You can also download Debian packages from the [packaging][packaging/debian] repo.
@@ -94,7 +94,7 @@ Available for most distributions, snap packages are simple to install and are
 automatically updated.
 
 ```sh
-$ sudo snap install eask-cli
+sudo snap install eask-cli
 ```
 
 ### 📦 Arch (Linux)
@@ -103,7 +103,7 @@ There's a `PKGBUILD` that builds `eask` from sources and creates a package, so
 inside the top directory of the repository you can simply run:
 
 ```sh
-$ makepkg -i
+makepkg -i
 ```
 
 ### 📦 Chocolatey (Windows)
@@ -112,7 +112,7 @@ If you have [Chocolatey][] installed on your machine, you can
 install Eask with the following one-liner:
 
 ```sh
-$ choco install eask-cli
+choco install eask-cli
 ```
 
 ### 📦 Scoop (Windows)
@@ -121,15 +121,15 @@ $ choco install eask-cli
 To install the Eask CLI:
 
 ```sh
-$ scoop bucket add extras
-$ scoop install eask-cli
+scoop bucket add extras
+scoop install eask-cli
 ```
 
 Alternatively, you can use our bucket to access the latest release.
 
 ```sh
-$ scoop bucket add emacs-eask/cli https://github.com/emacs-eask/packaging
-$ scoop install eask-cli
+scoop bucket add emacs-eask/cli https://github.com/emacs-eask/packaging
+scoop install eask-cli
 ```
 
 ### 📦 Winget (Windows)
@@ -138,7 +138,7 @@ $ scoop install eask-cli
 To install the Eask CLI:
 
 ```
-$ winget install eask.cli
+winget install eask.cli
 ```
 
 ## 💾 Build from source
@@ -153,13 +153,13 @@ Alternatively, you can clone it directly from this repo
 
 ```sh
 # clone the repo
-$ git clone https://github.com/emacs-eask/cli eask-cli
+git clone https://github.com/emacs-eask/cli eask-cli
 
 # change the working directory to eask-cli
-$ cd eask-cli
+cd eask-cli
 
 # install the requirements
-$ npm install
+npm install
 ```
 
 ### 🏡 Setup (through script)
@@ -188,12 +188,12 @@ To run `eask` through executable, you will need [pkg][] installed on your machin
 
 ```sh
 # install it locally in the workspace scope
-$ npm install --dev
+npm install --dev
 
 # or
 
 # install it globally
-$ npm install -g pkg
+npm install -g pkg
 ```
 
 Subsequently, run the following command to build the executable.
@@ -201,7 +201,7 @@ By default, it will generate an executable in the `dist` folder.
 
 ```sh
 # build from sources. For available targets see `scripts` in `package.json`
-$ npm run pkg-linux-x64
+npm run pkg-linux-x64
 
 # move `lisp` to `dist` folder
 mv lisp dist

--- a/docs/content/Getting-Started/Install-Eask/_index.zh-tw.md
+++ b/docs/content/Getting-Started/Install-Eask/_index.zh-tw.md
@@ -21,13 +21,13 @@ weight: 200
 在 macOS 或 Linux:
 
 ```sh
-$ curl -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.sh | sh
 ```
 
 在 Windows:
 
 ```sh
-$ curl.exe -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.bat | cmd /Q
+curl.exe -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinstall/install.bat | cmd /Q
 ```
 
 ## 💾 包管理器
@@ -37,7 +37,7 @@ $ curl.exe -fsSL https://raw.githubusercontent.com/emacs-eask/cli/master/webinst
 如果您的機器上安裝了 [npm][]，您可以使用以下一行代碼安裝 Eask：
 
 ```sh
-$ npm install -g @emacs-eask/cli
+npm install -g @emacs-eask/cli
 ```
 
 ### 📦 Nix (macOS 或 Linux)
@@ -46,7 +46,7 @@ $ npm install -g @emacs-eask/cli
 若要安裝 Eask CLI，請執行下列操作：
 
 ```sh
-$ nix profile install nixpkgs#eask-cli
+nix profile install nixpkgs#eask-cli
 ```
 
 ### 📦 Homebrew (macOS 或 Linux)
@@ -55,8 +55,8 @@ $ nix profile install nixpkgs#eask-cli
 若要安裝 Eask CLI，請執行下列操作：
 
 ```sh
-$ brew tap emacs-eask/cli https://github.com/emacs-eask/packaging
-$ brew install eask-cli
+brew tap emacs-eask/cli https://github.com/emacs-eask/packaging
+brew install eask-cli
 ```
 
 ### 📦 MacPorts (macOS)
@@ -65,7 +65,7 @@ $ brew install eask-cli
 若要安裝 Eask CLI，請執行下列操作：
 
 ```sh
-$ sudo port install eask-cli
+sudo port install eask-cli
 ```
 
 ### 📦 Debian (Linux)
@@ -75,10 +75,10 @@ Linux [Debian][] 發行版的衍生版本包括 [elementary OS][]、[KDE neon][]
 [Zorin OS][] 等。
 
 ```sh
-$ sudo curl -SsL -o /etc/apt/trusted.gpg.d/easksource.gpg https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/KEY.gpg
-$ sudo curl -SsL -o /etc/apt/sources.list.d/easksource.list https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/easksource.list
-$ sudo apt update --allow-insecure-repositories
-$ sudo apt install eask-cli --allow-unauthenticated
+sudo curl -SsL -o /etc/apt/trusted.gpg.d/easksource.gpg https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/KEY.gpg
+sudo curl -SsL -o /etc/apt/sources.list.d/easksource.list https://raw.githubusercontent.com/emacs-eask/packaging/master/debian/easksource.list
+sudo apt update --allow-insecure-repositories
+sudo apt install eask-cli --allow-unauthenticated
 ```
 
 您也可以直接從 [packaging][packaging/debian] 代碼庫下載 Debian 軟體包。
@@ -89,7 +89,7 @@ $ sudo apt install eask-cli --allow-unauthenticated
 snap 套件適用於大多數發行版，安裝簡單且會自動更新。
 
 ```sh
-$ sudo snap install eask-cli
+sudo snap install eask-cli
 ```
 
 ### 📦 Arch (Linux)
@@ -97,7 +97,7 @@ $ sudo snap install eask-cli
 有一個 `PKGBUILD` 可以從原始程式碼建立 `eask` 並建立一個包，因此在儲存庫的最上層目錄中您可以簡單地運行：
 
 ```sh
-$ makepkg -i
+makepkg -i
 ```
 
 ### 📦 Chocolatey (Windows)
@@ -105,7 +105,7 @@ $ makepkg -i
 如果您的計算機上安裝了 [Chocolatey][]，則可以使用以下一行代碼安裝 Eask：
 
 ```sh
-$ choco install eask-cli
+choco install eask-cli
 ```
 
 ### 📦 Scoop (Windows)
@@ -114,15 +114,15 @@ $ choco install eask-cli
 若要安裝 Eask CLI，請執行下列操作：
 
 ```sh
-$ scoop bucket add extras
-$ scoop install eask-cli
+scoop bucket add extras
+scoop install eask-cli
 ```
 
 另外，您也可以使用我們的 bucket 來獲得最新版本。
 
 ```sh
-$ scoop bucket add emacs-eask/cli https://github.com/emacs-eask/packaging
-$ scoop install eask-cli
+scoop bucket add emacs-eask/cli https://github.com/emacs-eask/packaging
+scoop install eask-cli
 ```
 
 ### 📦 Winget (Windows)
@@ -131,7 +131,7 @@ $ scoop install eask-cli
 若要安裝 Eask CLI，請執行下列操作：
 
 ```
-$ winget install eask.cli
+winget install eask.cli
 ```
 
 ## 💾 從原始碼構建
@@ -146,18 +146,18 @@ $ winget install eask.cli
 
 ```sh
 # 克隆這個代碼庫
-$ git clone https://github.com/emacs-eask/cli eask-cli
+git clone https://github.com/emacs-eask/cli eask-cli
 
 # 將工作目錄更改為 eask-cli
-$ cd eask-cli
+cd eask-cli
 
 # 安裝所有依賴
-$ npm install
+npm install
 ```
 
 ```sh
 # 從源頭建構; 有關可用目標，請參閱 `package.json` 中的 `scripts`
-$ npm run pkg-linux-x64
+npm run pkg-linux-x64
 ```
 
 ### 🏡 設定（透過腳本）
@@ -184,12 +184,12 @@ To run `eask` through executable, you will need [pkg][] installed on your machin
 
 ```sh
 # 區域安裝
-$ npm install --dev
+npm install --dev
 
 # 或
 
 # 全域安裝
-$ npm install -g pkg
+npm install -g pkg
 ```
 
 隨後，執行以下命令產生可執行檔。
@@ -197,7 +197,7 @@ $ npm install -g pkg
 
 ```sh
 # 從原始碼建置。有關可用目標，請參閱 `package.json` 中的 `scripts` 。
-$ npm run pkg-linux-x64
+npm run pkg-linux-x64
 
 # 將 `lisp` 移至 `dist` 資料夾
 mv lisp dist

--- a/docs/content/Getting-Started/Quick-Start/_index.en.md
+++ b/docs/content/Getting-Started/Quick-Start/_index.en.md
@@ -31,13 +31,13 @@ from our [release](https://github.com/emacs-eask/cli/releases) page.
 ## 🔍 Step 2: Install Eask
 
 ```sh
-$ npm install -g @emacs-eask/cli
+npm install -g @emacs-eask/cli
 ```
 
 To verify your new installation:
 
 ```sh
-$ eask --version
+eask --version
 ```
 
 ## 🔍 Step 3: Navigate to an existing project or create a new project
@@ -46,13 +46,13 @@ If you already have an existing elisp project, navigate to the project root
 folder.
 
 ```sh
-$ cd /path/to/project/dir/
+cd /path/to/project/dir/
 ```
 
 To create one:
 
 ```sh
-$ eask create package <your-project>
+eask create package <your-project>
 ```
 
 It should create a folder named `<your-project>` in your current working directory.
@@ -64,7 +64,7 @@ Skip this step if you chose to create the project with **`eask create`**!
 Otherwise, to create Eask-file in the existing project:
 
 ```sh
-$ eask init
+eask init
 ```
 
 You will be asked some questions about the package you are going to create:
@@ -105,7 +105,7 @@ You should be able to see an `Eask` file in your project folder. 🎉🎊
 To check your package information, run:
 
 ```sh
-$ eask info
+eask info
 ```
 
 You should be able to see the following information:
@@ -162,7 +162,7 @@ Or else you would get an error **`package-name-' is unavailable**!
 Now we can install the dependencies we have specified in the **Eask**-file:
 
 ```sh
-$ eask install-deps
+eask install-deps
 ```
 
 You should see Eask executed correctly with the similar output below:

--- a/docs/content/Getting-Started/Quick-Start/_index.zh-tw.md
+++ b/docs/content/Getting-Started/Quick-Start/_index.zh-tw.md
@@ -28,13 +28,13 @@ weight: 100
 ## 🔍 步驟 2: 安裝 Eask
 
 ```sh
-$ npm install -g @emacs-eask/cli
+npm install -g @emacs-eask/cli
 ```
 
 驗證您的新安裝：
 
 ```sh
-$ eask --version
+eask --version
 ```
 
 ## 🔍 步驟 3: 導航到現有項目或創建新項目
@@ -42,13 +42,13 @@ $ eask --version
 如果您已有一個現有的 elisp 項目，請導航到項目根文件夾。
 
 ```sh
-$ cd /path/to/project/dir/
+cd /path/to/project/dir/
 ```
 
 創建一個：
 
 ```sh
-$ eask create package <your-project>
+eask create package <your-project>
 ```
 
 它應該在您當前的工作目錄中創建一個名為 `<your-project>` 的文件夾。
@@ -60,7 +60,7 @@ $ eask create package <your-project>
 否則，在現有項目中創建 Eask 文件：
 
 ```sh
-$ eask init
+eask init
 ```
 
 您將被問到一些關於您將要創建的包的問題：
@@ -101,7 +101,7 @@ Is this OK? (yes) yes ⏎
 要檢查您的包裹信息，請運行：
 
 ```sh
-$ eask info
+eask info
 ```
 
 您應該能夠看到以下信息：
@@ -158,7 +158,7 @@ dist
 現在我們可以安裝我們在 **Eask** 文件中指定的依賴項：
 
 ```sh
-$ eask install-deps
+eask install-deps
 ```
 
 您應該會看到 Eask 正確執行，輸出類似如下：


### PR DESCRIPTION
The command can be copied from GitHub into CLI with no modification