### PR TITLE
Set error status when help is printed

### DIFF
--- a/.github/workflows/help_exit.yml
+++ b/.github/workflows/help_exit.yml
@@ -25,38 +25,15 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        emacs-version:
-          - 26.3
-          - 27.2
-          - 28.2
-          - 29.4
-          - 30.1
-        experimental: [false]
-        include:
-          - os: ubuntu-latest
-            emacs-version: snapshot
-            experimental: true
-          - os: macos-latest
-            emacs-version: snapshot
-            experimental: true
-          - os: windows-latest
-            emacs-version: snapshot
-            experimental: true
-        exclude:
-          - os: macos-latest
-            emacs-version: 26.3
-          - os: macos-latest
-            emacs-version: 27.2
 
     steps:
     - uses: jcs090218/setup-emacs@master
       with:
-        version: ${{ matrix.emacs-version }}
+        version: 30.1
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/help_exit.yml
+++ b/.github/workflows/help_exit.yml
@@ -1,0 +1,75 @@
+name: Help-Exit
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'eask'
+      - '**.yml'
+      - lisp/**
+      - cmds/**
+      - src/**
+      - test/**
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 26.3
+          - 27.2
+          - 28.2
+          - 29.4
+          - 30.1
+        experimental: [false]
+        include:
+          - os: ubuntu-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: macos-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: windows-latest
+            emacs-version: snapshot
+            experimental: true
+        exclude:
+          - os: macos-latest
+            emacs-version: 26.3
+          - os: macos-latest
+            emacs-version: 27.2
+
+    steps:
+    - uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: actions/checkout@v4
+
+    - name: Prepare Eask (Unix)
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      run: |
+        chmod -R 777 ./
+        .github/scripts/setup-eask
+
+    - name: Prepare Eask (Windows)
+      if: matrix.os == 'windows-latest'
+      run: .github/scripts/setup-eask.ps1
+
+    - name: Testing...
+      run: |
+        make command-help-exit

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ command-config:
 command-local:
 	./test/commands/local/run.sh
 
+# new tests which check missing args not covered by existing tests
+command-help-exit: command-bump command-concat command-docs command-eval command-format command-info command-init command-lint command-recipe command-run command-source
+
 command-analyze:
 	./test/commands/analyze/dsl/run.sh
 	./test/commands/analyze/metadata/run.sh

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,25 @@ command-local:
 command-analyze:
 	./test/commands/analyze/dsl/run.sh
 	./test/commands/analyze/metadata/run.sh
+	./test/commands/analyze/error/run.sh
+
+command-bump:
+	./test/commands/bump/run.sh
+
+command-compile:
+	./test/commands/compile/run.sh
+
+command-concat:
+	./test/commands/concat/run.sh
 
 command-docker:
 	./test/commands/docker/run.sh
+
+command-docs:
+	./test/commands/docs/run.sh
+
+command-eval:
+	./test/commands/eval/run.sh
 
 command-exec:
 	./test/commands/exec/run.sh
@@ -45,17 +61,38 @@ command-exec:
 command-emacs:
 	./test/commands/emacs/run.sh
 
+command-format:
+	./test/commands/format/run.sh
+
+command-info:
+	./test/commands/info/run.sh
+
+command-init:
+	./test/commands/init/run.sh
+
 command-install:
 	./test/commands/install/run.sh
+
+command-link:
+	./test/commands/link/run.sh
+
+command-lint:
+	./test/commands/lint/run.sh
 
 command-outdated-upgrade:
 	./test/commands/outdated_upgrade/run.sh
 
+command-recipe:
+	./test/commands/recipe/run.sh
+
+command-run:
+	./test/commands/run/run.sh
+
 command-search:
 	./test/commands/search/run.sh
 
-command-link:
-	./test/commands/link/run.sh
+command-source:
+	./test/commands/source/run.sh
 
 test-ert:
 	./test/commands/test/ert/run.sh

--- a/cmds/run/script.js
+++ b/cmds/run/script.js
@@ -21,7 +21,7 @@ const fs = require('fs');
 const child_process = require("child_process");
 
 exports.command = ['script [names..]'];
-exports.desc = 'Run script nameds [names..]';
+exports.desc = 'Run script named [names..]';
 exports.builder = yargs => yargs
   .positional(
     '[names..]', {

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -1860,10 +1860,21 @@ Arguments FNC and ARGS are used for advice `:around'."
     (eask-msg (ansi-white (buffer-string)))
     (eask-msg (concat "''" (spaces-string max-column) "''"))))
 
-(defun eask-help (command)
-  "Show COMMAND's help instruction."
+(defun eask-help (command &optional print-or-exit-code)
+  "Show COMMAND's help instruction.
+
+When the optional variable PRINT-OR-EXIT-CODE is a number, it will exit with
+that code.  Set to non-nil would just print the help message without sending
+the exit code.  The default value `nil' will be replaced by `1'; therefore
+would send exit code of `1'."
   (let* ((command (eask-2str command))  ; convert to string
-         (help-file (concat eask-lisp-root "help/" command)))
+         (help-file (concat eask-lisp-root "help/" command))
+         ;; The default exit code is `1' since `eask-help' prints the help
+         ;; message on user error 99% of the time.
+         ;;
+         ;; TODO: Later replace exit code `1' with readable symbol after
+         ;; the exit code has specified.
+         (print-or-exit-code (or print-or-exit-code 1)))
     (if (file-exists-p help-file)
         (with-temp-buffer
           (insert-file-contents help-file)
@@ -1871,7 +1882,11 @@ Arguments FNC and ARGS are used for advice `:around'."
             (let ((buf-str (eask--msg-displayable-kwds (buffer-string))))
               (erase-buffer)
               (insert buf-str))
-            (eask--help-display)))
+            (eask--help-display))
+          ;; Exit with code if needed
+          (cond ((numberp print-or-exit-code)
+                 (eask--exit print-or-exit-code))
+                (t )))  ; Don't exit with anything else.
       (eask-error "Help manual missing %s" help-file))))
 
 ;;

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -1870,14 +1870,14 @@ Arguments FNC and ARGS are used for advice `:around'."
               (erase-buffer)
               (insert buf-str))
             (eask--help-display)))
-      (eask-error "Help manual missig %s" help-file))))
+      (eask-error "Help manual missing %s" help-file))))
 
 ;;
 ;;; Checker
 
 (defun eask--checker-existence ()
   "Return errors if required metadata is missing."
-  (unless eask-package (eask-error "Missing metadata package; make sure you have create Eask-file with $ eask init!")))
+  (unless eask-package (eask-error "Missing metadata package; make sure you have created an Eask-file with $ eask init!")))
 
 (defun eask--check-strings (fmt f p &rest args)
   "Test strings (F and P); then print FMT and ARGS if not equal."

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -1727,7 +1727,9 @@ Argument ARGS are direct arguments for functions `eask-error' or `eask-warn'."
   (declare (indent 0) (debug t))
   `(eask-ignore-errors (eask--silent-error ,@body)))
 
-(defun eask--exit (&rest _) "Send exit code." (kill-emacs 1))
+(defun eask--exit (&optional exit-code &rest _)
+  "Kill Emacs with EXIT-CODE (default 1)."
+  (kill-emacs (or exit-code 1)))
 
 (defun eask--trigger-error ()
   "Trigger error event."

--- a/lisp/core/analyze.el
+++ b/lisp/core/analyze.el
@@ -152,6 +152,6 @@ Argument LEVEL and MSG are data from the debug log signal."
    ;; Default, print help!
    (t
     (eask-info "(No Eask-files have been checked)")
-    (eask-help "checker/analyze"))))
+    (eask-help "core/analyze"))))
 
 ;;; core/analyze.el ends here

--- a/lisp/help/core/analyze
+++ b/lisp/help/core/analyze
@@ -1,4 +1,4 @@
-    
-💡 You need to specify file(s) you want to Eask checker to check
+
+💡 You need to specify file(s) you want Eask checker to check
 
     $ eask analyze FILE-1 FILE-2

--- a/lisp/help/core/concat
+++ b/lisp/help/core/concat
@@ -1,4 +1,4 @@
 
-💡 You would need to specify the [names..] in order to make concatenation!
+💡 You need to specify the file [names..] in order to concatenate!
 
     $ eask concat [names..]

--- a/lisp/help/core/docs
+++ b/lisp/help/core/docs
@@ -1,4 +1,4 @@
 
-💡 You would need to specify the [names..] in order to build documentation!
+💡 You need to specify the file [names..] in order to build documentation!
 
     $ eask docs [names..]

--- a/lisp/help/core/eval
+++ b/lisp/help/core/eval
@@ -1,4 +1,4 @@
 
-💡 You would need to specify the [form] in order to make execution!
+💡 You need to specify the [form] to evaluate!
 
     $ eask eval [form]

--- a/lisp/help/core/exec
+++ b/lisp/help/core/exec
@@ -1,4 +1,4 @@
 
-💡 You would need to specify the program name in order to make execution!
-   
+💡 You need to specify the program name to execute!
+
     $ eask exec <program> [options..]

--- a/lisp/help/core/info
+++ b/lisp/help/core/info
@@ -1,5 +1,5 @@
 
-💡 You need Eask-file to show information about the config/package, to create one:
+💡 You need an Eask-file to show information about the config/package; to create one:
 
     $ eask init
 

--- a/lisp/help/core/install-deps
+++ b/lisp/help/core/install-deps
@@ -1,4 +1,4 @@
 
-💡 You can add dependencies by using specifier [depends-on]
+💡 You can add dependencies by using the specifier [depends-on]
 
     [+] (depends-on "PKG-SPEC")

--- a/lisp/help/core/recipe
+++ b/lisp/help/core/recipe
@@ -1,5 +1,5 @@
 
-💡 Please specify URL: in your main package file
+💡 Please specify URL in your main package file:
 
     [+] ;; URL: https://example.com/your/repo/url
 

--- a/lisp/help/core/reinstall
+++ b/lisp/help/core/reinstall
@@ -1,13 +1,13 @@
-    
-💡 Make sure you have specify a (package-file ..) directive inside your Eask file!
-   
+
+💡 Make sure you have specified a (package-file ..) directive inside your Eask file!
+
     [+] (package-file "PKG-MAIN.el")
-    
+
 💡 Or specify package names as arguments
-   
+
     $ eask reinstall PKG-1 PKG-2
-    
-💡 You would need to first install packages before reinstalling!
+
+💡 You first need to install packages before reinstalling!
 
   Try the command:
 

--- a/lisp/help/core/search
+++ b/lisp/help/core/search
@@ -1,4 +1,4 @@
 
-💡 You would need to specify queries to do search operations
+💡 You need to specify queries to search for
 
     $ eask search QUERY-1 QUERY-2 ..

--- a/lisp/help/core/uninstall
+++ b/lisp/help/core/uninstall
@@ -1,6 +1,6 @@
 
-💡 Make sure you have specify a (package-file ..) inside your Eask file!
    
+💡 Make sure you have specified a (package-file ..) inside your Eask file!
     [+] (package-file "PKG-MAIN.el")
     
 💡 Or specify package names as arguments

--- a/lisp/help/format/elfmt
+++ b/lisp/help/format/elfmt
@@ -1,9 +1,9 @@
 
-💡 You need to specify file(s) you want the elfmt to run
+💡 You need to specify file(s) you want elfmt to format
 
     $ eask format elfmt FILE-1 FILE-2
 
-💡 Or edit Eask file with [package-file] or [files] specifier
+💡 Or edit the Eask-file with [package-file] or [files] specifier
 
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns

--- a/lisp/help/format/elisp-autofmt
+++ b/lisp/help/format/elisp-autofmt
@@ -1,9 +1,9 @@
 
-💡 You need to specify file(s) you want the elisp-autofmt to run
+💡 You need to specify file(s) you want elisp-autofmt to format
 
     $ eask format elisp-autofmt FILE-1 FILE-2
 
-💡 Or edit Eask file with [package-file] or [files] specifier
+💡 Or edit the Eask-file with [package-file] or [files] specifier
 
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns

--- a/lisp/help/link/add/error
+++ b/lisp/help/link/add/error
@@ -1,6 +1,6 @@
 
-💡 You need the `-pkg.el` file so the `package.el` can recognize your package.
    
+💡 You need the `-pkg.el` file so that `package.el` can recognize your package.
 Options are,
    
   - [ ] Use `eask generate pkg-file` to create one

--- a/lisp/help/lint/checkdoc
+++ b/lisp/help/lint/checkdoc
@@ -1,9 +1,9 @@
 
-💡 You need to specify file(s) you want the checkdoc to run
+💡 You need to specify file(s) you want checkdoc to run
 
     $ eask lint checkdoc FILE-1 FILE-2
 
-💡 Or edit Eask file with [package-file] or [files] specifier
+💡 Or edit the Eask-file with [package-file] or [files] specifier
 
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns

--- a/lisp/help/lint/declare
+++ b/lisp/help/lint/declare
@@ -1,9 +1,9 @@
 
-💡 You need to specify file(s) you want the check-declare to run
+💡 You need to specify file(s) you want check-declare to check
 
     $ eask lint declare FILE-1 FILE-2
 
-💡 Or edit Eask file with [package-file] or [files] specifier
+💡 Or edit the Eask-file with [package-file] or [files] specifier
 
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns

--- a/lisp/help/lint/elint
+++ b/lisp/help/lint/elint
@@ -1,13 +1,13 @@
-    
-💡 You need to specify file(s) you want the elint to run
-   
+
+💡 You need to specify file(s) you want elint to check
+
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns
 
 For example,
-    
+
     [+] (files "*.el")
 
 💡 Tip: You can use the command [files] to show all selected files
-   
+
     $ eask files

--- a/lisp/help/lint/elisp-lint
+++ b/lisp/help/lint/elisp-lint
@@ -1,13 +1,13 @@
-    
-💡 You need to specify file(s) you want the elisp-lint to run
-   
+
+
+💡 You need to specify file(s) you want elisp-lint to check
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns
 
 For example,
-    
+
     [+] (files "*.el")
 
 💡 Tip: You can use the command [files] to show all selected files
-   
+
     $ eask files

--- a/lisp/help/lint/elsa
+++ b/lisp/help/lint/elsa
@@ -1,13 +1,13 @@
-    
-💡 You need to specify file(s) you want the elsa to run
-   
+
+💡 You need to specify file(s) you want elsa to check
+
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns
 
 For example,
-    
+
     [+] (files "*.el")
 
 💡 Tip: You can use the command [files] to show all selected files
-   
+
     $ eask files

--- a/lisp/help/lint/indent
+++ b/lisp/help/lint/indent
@@ -1,13 +1,13 @@
-    
-💡 You need to specify file(s) you want the indent-lint to run
-   
+
+
+💡 You need to specify file(s) you want indent-lint to check
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns
 
 For example,
-    
+
     [+] (files "*.el")
 
 💡 Tip: You can use the command [files] to show all selected files
-   
+
     $ eask files

--- a/lisp/help/lint/package
+++ b/lisp/help/lint/package
@@ -1,13 +1,13 @@
-    
-💡 You need to specify file(s) you want the package-lint to run
-   
+
+💡 You need to specify file(s) you want package-lint to check
+
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns
 
 For example,
-    
+
     [+] (files "*.el")
 
 💡 Tip: You can use the command [files] to show all selected files
-   
+
     $ eask files

--- a/lisp/help/lint/regexps
+++ b/lisp/help/lint/regexps
@@ -1,13 +1,13 @@
-    
-💡 You need to specify file(s) you want the relint to run
-   
+
+💡 You need to specify file(s) you want relint to check
+
     [+] (package-file "ENTRY")         ; One argument with a string
     [+] (files "FILE-1" "FILE-2" ...)  ; All arguments are wildcard patterns
 
 For example,
-    
+
     [+] (files "*.el")
 
 💡 Tip: You can use the command [files] to show all selected files
-   
+
     $ eask files

--- a/lisp/help/run/command
+++ b/lisp/help/run/command
@@ -1,5 +1,5 @@
 
-💡 Make sure you have specify a (eask-defcommand ..) function inside your Eask file!
+💡 Make sure you have specified a (eask-defcommand ..) function inside your Eask file!
 
     [+] (eask-defcommand my-command
     [+]   "This is a test command."

--- a/lisp/help/source/add
+++ b/lisp/help/source/add
@@ -1,7 +1,5 @@
 
-💡 The given source name is not found in our database. You have following options:
-
-Options are,
+💡 The given source name is not found in our database. You have the following options:
 
   - [ ] Pass in one extra argument to specify an `[url]`
   - [ ] Edit variable `eask-source-mapping` and create a pull request to https://github.com/emacs-eask/cli

--- a/lisp/help/test/ert
+++ b/lisp/help/test/ert
@@ -1,4 +1,4 @@
 
-💡 You need to specify the file(s) you want the ert to run:
+💡 You need to specify the file(s) you want ert to run:
 
     $ eask test ert FILE-1 FILE-2

--- a/lisp/help/test/melpazoid
+++ b/lisp/help/test/melpazoid
@@ -1,4 +1,4 @@
 
-💡 You need to specify the directory(ies) you want the melpazoid to run:
+💡 You need to specify the directory(ies) you want melpazoid to run:
 
     $ eask test melpazoid DIR-1 DIR2

--- a/lisp/link/add.el
+++ b/lisp/link/add.el
@@ -83,7 +83,7 @@
           (eask-link-add--create source)
           (when (and (zerop (length links))         ; if no link previously,
                      (= 1 (length (eask-link-list))))  ; and first link created!
-            (eask-help "link/add/success/pkg")))
+            (eask-help "link/add/success/pkg" t))) ;; don't error
          ((ignore-errors (file-exists-p pkg-eask))
           (eask-log "💡 Validating package through %s... done!" pkg-eask)
           (eask--save-load-eask-file pkg-eask
@@ -113,7 +113,7 @@
                 (eask-link-add--create source)
                 (when (and (zerop (length links))         ; if no link previously,
                            (= 1 (length (eask-link-list))))  ; and first link created!
-                  (eask-help "link/add/success/eask")))
+                  (eask-help "link/add/success/eask" t))) ;; don't error
             (eask-error "✗ Error loading Eask-file: %s" pkg-eask)))
          (t
           (eask-info "(Missing `%s-pkg.el` file in your source folder)" name)

--- a/test/commands/analyze/error/run.sh
+++ b/test/commands/analyze/error/run.sh
@@ -17,41 +17,15 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/analyze `analyze` errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
 # Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing analyze command... no files"
+should_error eask analyze

--- a/test/commands/bump/run.sh
+++ b/test/commands/bump/run.sh
@@ -17,41 +17,15 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/bump `bump` errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
 # Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing bump command... no files"
+should_error eask bump

--- a/test/commands/compile/run.sh
+++ b/test/commands/compile/run.sh
@@ -17,41 +17,14 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/compile `compile` errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
-# Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing compile command... no files"
+should_error eask compile

--- a/test/commands/concat/run.sh
+++ b/test/commands/concat/run.sh
@@ -17,41 +17,15 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/concat `concat` errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
 # Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing concat command... no files"
+should_error eask concat

--- a/test/commands/docs/run.sh
+++ b/test/commands/docs/run.sh
@@ -17,41 +17,15 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/docs `docs` errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
 # Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing docs command... no files"
+should_error eask docs

--- a/test/commands/eval/run.sh
+++ b/test/commands/eval/run.sh
@@ -17,41 +17,14 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/eval `eval` errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
-# Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing eval command... no arg"
+should_error eask eval

--- a/test/commands/exec/run.sh
+++ b/test/commands/exec/run.sh
@@ -22,6 +22,8 @@
 
 set -e
 
+source ./test/fixtures/home/scripts/testing.sh
+
 echo "Test command 'exec'..."
 cd $(dirname "$0")
 
@@ -32,3 +34,6 @@ eask exec echo hello world
 
 eask exec buttercup -L .
 eask exec buttercup -L . --pattern 'pattern 1'
+
+echo "Testing exec command... no files"
+should_error eask exec

--- a/test/commands/format/run.sh
+++ b/test/commands/format/run.sh
@@ -17,41 +17,17 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/format errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
-# Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
+echo "Testing elfmt command... no files"
+should_error eask format elfmt
 
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing elisp-autofmt command... no files"
+should_error eask format elisp-autofmt

--- a/test/commands/info/run.sh
+++ b/test/commands/info/run.sh
@@ -17,41 +17,13 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/info errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
-# Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
-cd $(dirname "$0")
-should_error eask install
-
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing info command... no files"
+should_error eask -g info
+# When run in the current directory this sees the eask file from the main project

--- a/test/commands/init/run.sh
+++ b/test/commands/init/run.sh
@@ -17,41 +17,23 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test eask init errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
-# Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
+echo "Testing init --from cask command... no files"
+should_error eask init --from cask
 
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing init --from keg command... no files"
+should_error eask init --from keg
+
+echo "Testing init --from eldev command... no files"
+should_error eask init --from eldev
+
+echo "Testing init --from source command... no files"
+should_error eask init --from source

--- a/test/commands/link/run.sh
+++ b/test/commands/link/run.sh
@@ -26,6 +26,15 @@
 
 set -e
 
+source ./test/fixtures/home/scripts/testing.sh
+
 eask link add "mini.pkg.1" "./test/fixtures/mini.pkg.1/"
 eask link list
 eask link delete mini.pkg.1-0.0.1
+
+cd $(dirname "$0")
+
+echo "Testing link command... no files"
+should_error eask link add       # not enough args
+should_error eask link add foo . # missing package, prints help
+should_error eask link delete

--- a/test/commands/lint/run.sh
+++ b/test/commands/lint/run.sh
@@ -17,41 +17,36 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/lint errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
 # Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
+echo "Testing lint checkdoc command... no files"
+should_error eask lint checkdoc
 
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing lint declare command... no files"
+should_error eask lint declare
+
+echo "Testing lint elint command... no files"
+should_error eask lint elint
+
+echo "Testing lint elisp-lint command... no files"
+should_error eask lint elisp-lint
+
+echo "Testing lint elsa command... no files"
+should_error eask lint elsa
+
+echo "Testing lint indent command... no files"
+should_error eask lint indent
+
+echo "Testing lint keywords command... no files"
+should_error eask lint keywords
+
+echo "Testing lint regexps command... no files"
+should_error eask lint regexps

--- a/test/commands/recipe/run.sh
+++ b/test/commands/recipe/run.sh
@@ -17,41 +17,15 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/recipe `recipe` errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
 # Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
-
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing recipe command... no files"
+should_error eask recipe

--- a/test/commands/run/run.sh
+++ b/test/commands/run/run.sh
@@ -17,41 +17,17 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/run errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
-# Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
+echo "Testing 'run command' command... no files"
+should_error eask run command
 
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+echo "Testing 'run script' command... no files"
+should_error eask run script -g   # needs to avoid parent Eask file

--- a/test/commands/search/run.sh
+++ b/test/commands/search/run.sh
@@ -22,10 +22,12 @@
 
 set -e
 
+source ./test/fixtures/home/scripts/testing.sh
+
 echo "Test command 'search'..."
 cd $(dirname "$0")
 
-eask search
+should_error eask search
 eask search company
 eask search company dash --depth 0
 eask search company dash f s --depth 0 -g

--- a/test/commands/source/run.sh
+++ b/test/commands/source/run.sh
@@ -17,41 +17,19 @@
 
 ## Commentary:
 #
-# Test commands related to install, and uninstall
+# Test command/source errors
 #
 
 set -e
 
 source ./test/fixtures/home/scripts/testing.sh
 
-echo "Test commands related to install, and uninstall"
-
-# Naviate to the test package
-cd "./test/fixtures/mini.pkg.1/"
-
-echo "Install dependencies"
-eask install-deps
-
-echo "Install project package"
-eask package
-eask install
-
-echo "Install by sepcifying packages"
-eask install beacon company-fuzzy transwin
-
-echo "Uninstall by sepcifying packages"
-eask uninstall beacon transwin
-
-echo "Uninstall project package"
-eask uninstall
-
-echo "Test eask install ... no files"
-cd -
 cd $(dirname "$0")
-should_error eask install
 
-echo "Test eask uninstall ... no files"
-should_error eask uninstall
+echo "Testing source command... errors"
+should_error eask source
+should_error eask source add
+should_error eask source add foo # name not found, show help
 
-echo "Test eask reinstall ... no files"
-should_error eask reinstall
+should_error eask source delete
+should_error eask source delete foo # name not found, show help

--- a/test/commands/test/ert/run.sh
+++ b/test/commands/test/ert/run.sh
@@ -22,6 +22,8 @@
 
 set -e
 
+source ./test/fixtures/home/scripts/testing.sh
+
 echo "Test command 'ert'..."
 cd $(dirname "$0")
 
@@ -30,3 +32,6 @@ eask test ert ./test/*.el
 # regression
 echo "Test ert: nil message"
 eask test ert ./test-nil-message/*.el
+
+echo "Testing ert command... no files"
+should_error eask test ert

--- a/test/fixtures/home/scripts/testing.sh
+++ b/test/fixtures/home/scripts/testing.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Test reporting functions
+# This file will be sourced by other shell test scripts.
+# Expects to run with set -e
+
+# TODO note that eask output is always to stderr
+
+# Run command and exit with the same status
+# All args interpreted as program to run
+# e.g. should_run cmd arg1 arg2 ...
+should_run() {
+    echo "Run: $*"
+    echo "---------------"
+    "$@" 2>&1 | cat
+    local TEST_STATUS=${PIPESTATUS[0]}
+
+    echo ""
+
+    if [ $TEST_STATUS -gt 0 ]; then
+        printf "Fail: \'%s\' exited with status %s\n" "$*" "$TEST_STATUS" >&2
+        exit 1
+    fi
+}
+
+# Run command and exit with non-zero if command exits with zero.
+# All args interpreted as program to run
+# e.g. should_error cmd arg1 arg2 ...
+should_error() {
+    echo "Run: $*"
+    echo "---------------"
+    # a shorter alternative is
+    # ! "$@" || (echo "failed" && exit 1)
+
+    # this version allow for more formatting
+    "$@" 2>&1 | cat  # Exit status of individual commands in a pipeline are ignored
+    local TEST_STATUS=${PIPESTATUS[0]} # Get the true status, $? will always be 0
+
+    echo ""
+
+    if [ $TEST_STATUS -eq 0 ]; then
+        printf "Fail: \'%s\' should exit with non-zero status\n" "$*" >&2
+        exit 1
+    fi
+}
+
+# Check if (grep) pattern ARG1 is found in string ARG2
+# E.g. should_match "foo*" "foobar"
+should_match() {
+    echo "$2" | grep "$1"  - | cat > /dev/null
+    local SEARCH_RES=${PIPESTATUS[1]}
+
+    if [ $SEARCH_RES -gt 0 ]; then
+        printf "Fail: Output did not match \'%s\'\n" "$1"
+        exit 1
+    fi
+}

--- a/test/fixtures/mini.pkg.1/Eask
+++ b/test/fixtures/mini.pkg.1/Eask
@@ -3,7 +3,7 @@
          "Minimal test package")
 
 (website-url "https://github.com/emacs-eask/cli/tree/master/test/fixtures/mini.pkg.1")
-(keywords "test")
+(keywords "test" "local")
 
 (package-file "mini.pkg.1.el")
 

--- a/test/fixtures/mini.pkg.1/mini.pkg.1.el
+++ b/test/fixtures/mini.pkg.1/mini.pkg.1.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/emacs-eask/cli/tree/master/test/fixtures/mini.pkg.1
 ;; Version: 0.0.1
 ;; Package-Requires: ((emacs "24.3") (s "1.12.0") (fringe-helper "1.0.1"))
-;; Keywords: test
+;; Keywords: test local
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/test/options/run.sh
+++ b/test/options/run.sh
@@ -22,12 +22,14 @@
 
 set -e
 
+source ./test/fixtures/home/scripts/testing.sh
+
 echo "Test all options flag"
 cd $(dirname "$0")
 
 # Please have these flags in order, see `eask` file in the project root!
-eask info -g
-eask info --global
+should_error eask info -g
+should_error eask info --global
 eask info -a
 eask info --all
 eask info -q


### PR DESCRIPTION
This is an attempt to break down #275 into smaller chunks.

Many commands do not set a non-zero exit code when printing a help message , e.g. `eask eval` is 1, but  `eask exec` is 0.
Both should exit with 1.

Other fixes:
- some grammar/style improvements in the help messages
- fixed missing help message for `eask analyze`

**Comments**
Initially I thought to make `eask-help` always call `eask--exit`, but some help messages are just informational and should exit with 0, e.g. `eask link add` prints a message after it adds a link. Likely more would be in this category too, so `eask-help` should probably not change.

For now I added the new function `eask-help-error`, but I could equally well inline it too:
```elisp
;; within exec.el
(eask-help "core/exec")
(eask--exit)
```
this would avoid introducing a new function. Which do you prefer?

**Tests**
This removes some `FIXME`s from the new tests in #275 

I can either move the tests here into the appropriate folders, or rebase #275. 

I think it makes sense to move the tests, so that #275 gets smaller, but it would involve adding the script for the `should_error` helper in this PR.