### PR TITLE
Add option to install from a local file

### DIFF
--- a/cmds/core/install.js
+++ b/cmds/core/install.js
@@ -17,15 +17,27 @@
 
 "use strict";
 
-exports.command = ['install [names..]'];
-exports.desc = 'Install packages';
-exports.builder = yargs => yargs
-  .positional(
-    '[names..]', {
-      description: 'packages to install',
-      type: 'array',
+exports.command = ["install [names..]"];
+exports.desc = "Install packages";
+exports.builder = (yargs) =>
+  yargs
+    .positional("[names..]", {
+      description: "packages to install, or paths when --local is set",
+      type: "array",
+    })
+    .options({
+      local: {
+        description: "install from a local path",
+        type: "boolean",
+        group: TITLE_CMD_OPTION,
+      },
     });
 
 exports.handler = async (argv) => {
-  await UTIL.e_call(argv, 'core/install', argv.names);
+  await UTIL.e_call(
+    argv,
+    "core/install",
+    UTIL.def_flag(argv.local, "--local"),
+    argv.names,
+  );
 };

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -975,7 +975,8 @@ other scripts internally.  See function `eask-call'.")
      "--clean"
      "--json"
      "--number"
-     "--yes"))
+     "--yes"
+     "--local"))
   "List of boolean type options.")
 
 (defconst eask--option-args

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -647,7 +647,15 @@ If the argument FORCE is non-nil, force initialize packages in this session."
         (package-initialize t)
         (let ((eask--action-index 0)) (package-refresh-contents))
         (let ((eask--action-index 0)) (eask--download-archives)))
-      (ansi-green "done ✓"))))
+      (ansi-green "done ✓"))
+    (when-let* ((local-packages (eask-list-local-packages))
+                (local-package-paths (mapcar #'cdr local-packages)))
+     (eask-with-progress
+      (ansi-green "Refreshing local packages... \n")
+      (eask-with-verbosity 'log
+         ;; TODO this can run outside of the usual advice on error...
+         (with-demoted-errors "shh %s" (eask--package-mapc #'eask-package-local-install local-package-paths)))
+      (ansi-green "done ✓")))))
 
 (defun eask--pkg-transaction-vars (pkg)
   "Return 1 symbol and 2 strings.

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -1245,6 +1245,7 @@ This uses function `locate-dominating-file' to look up directory tree."
   "Execute BODY with workspace setup."
   (declare (indent 0) (debug t))
   `(unless eask-loading-file-p
+     (add-hook 'eask-after-command-hook #'eask--save-state)
      (if eask--initialized-p (progn ,@body)
        (setq eask--initialized-p t)
        (eask--setup-env
@@ -1813,7 +1814,10 @@ Argument ARGS are direct arguments for functions `eask-error' or `eask-warn'."
 
 (defun eask--exit (&optional exit-code &rest _)
   "Kill Emacs with EXIT-CODE (default 1)."
-  (kill-emacs (or exit-code 1)))
+  (setq exit-code (or exit-code 1))
+  (when (zerop exit-code)
+    (eask--save-state))
+  (kill-emacs exit-code))
 
 (defun eask--trigger-error ()
   "Trigger error event."

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -749,6 +749,16 @@ Argument BODY are forms for execution."
       (eask-ignore-errors (package-install-file (expand-file-name pkg-path))))
    "done ✓"))
 
+(defun eask-list-local-packages ()
+  "Alist of package name (symbol) to absolute path for local packages."
+  (eask-read-state-var 'local-packages))
+
+(defun eask-save-local-package (name path)
+  "Record local package NAME installed from PATH in Eask state."
+  (let* ((existing-packages (eask-read-state-var 'local-packages))
+         (updated-packages (seq-union (list (cons name path)) existing-packages)))
+    (eask-set-state-var 'local-packages updated-packages)))
+
 (defun eask-package-delete (pkg)
   "Delete the package (PKG)."
   (eask-defvc< 27 (eask-pkg-init)) ; XXX: remove this after we drop 26.x

--- a/lisp/core/install.el
+++ b/lisp/core/install.el
@@ -29,20 +29,14 @@
          (len (length names))
          (s (eask--sinr len "" "s"))
          (local-install (eask--flag "--local"))
-         (pkg-not-installed (if local-install
-                                names ;; always install local files
-                              (cl-remove-if #'package-installed-p names)))
+         (pkg-not-installed (cl-remove-if #'package-installed-p names))
          (installed (length pkg-not-installed))
          (skipped (- len installed)))
     (eask-log "Installing %s specified package%s..." len s)
     (eask-msg "")
     (if local-install
-        (progn
-          (let* ((local-packages-and-paths (eask-list-local-packages))
-                 (local-package-paths (mapcar #'cdr local-packages-and-paths))
-                 ;; TODO this may include duplicates as names may be relative paths
-                 (all-local-packages (seq-union names local-package-paths)))
-            (eask--package-mapc #'eask-package-local-install all-local-packages)))
+        ;; TODO this may include duplicates as names may be relative paths
+        (eask--package-mapc #'eask-package-local-install names)
       (eask--package-mapc #'eask-package-install names))
 
     (eask-msg "")

--- a/lisp/core/install.el
+++ b/lisp/core/install.el
@@ -38,16 +38,18 @@
     (eask-msg "")
     (if local-install
         (progn
-          (let* ((existing-local-packages (eask-read-state-var 'local-packages))
-                 (all-local-packages (seq-union names existing-local-packages)))
-            ;; try to install pacakges first, then save to avoid bugged state
-            (eask--package-mapc #'eask-package-local-install all-local-packages)
-            (eask-set-state-var 'local-packages all-local-packages)))
+          (let* ((local-packages-and-paths (eask-list-local-packages))
+                 (local-package-paths (mapcar #'cdr local-packages-and-paths))
+                 ;; TODO this may include duplicates as names may be relative paths
+                 (all-local-packages (seq-union names local-package-paths)))
+            (eask--package-mapc #'eask-package-local-install all-local-packages)))
       (eask--package-mapc #'eask-package-install names))
 
     (eask-msg "")
     (eask-info "(Total of %s package%s installed, %s skipped)"
-               installed s skipped)))
+               installed s skipped)
+    (eask--save-state) ;; TODO this should be in a lifecycle hook
+    ))
 
 ;; NOTE: This is copied from `eldev'! Great thanks!
 ;;

--- a/lisp/core/install.el
+++ b/lisp/core/install.el
@@ -47,9 +47,7 @@
 
     (eask-msg "")
     (eask-info "(Total of %s package%s installed, %s skipped)"
-               installed s skipped)
-    (eask--save-state) ;; TODO this should be in a lifecycle hook
-    ))
+               installed s skipped)))
 
 ;; NOTE: This is copied from `eldev'! Great thanks!
 ;;


### PR DESCRIPTION
**Rationale**
- I want to do `eask install --local ./some/path`.
- But how do I get fresh changes from `./some/path`, do I reinstall for every change?
- No: Have Eask install whenever `package-initialize` is run!
- But how does Eask know which packages to reinstall and from where?
- **Add local state**

**Changes**
Adds `--local` option to `eask install`. All args are interpreted as paths in that case.

Adds a few functions that save data in `.eask/ver/eask-state.el`:
```elisp
(eask-read-state-var 'local-packages) ;; alist of package-name to path
(eask-set-state-var 'local-packages '((foo . "./some/path")))
(eask--save-state)  ;; this is added to post-command-hook
```
Reinstalls saved `'local-packages` whenever `eask-pkg-init` is called.

**Notes**
- Might need to put the reinstall step somewhere other than `eask-pkg-init` if performance is bad
- Haven't tested it a lot

**TODOs**
- [ ] uninstall a local package
- [ ] display local package source in `eask list`
- [ ] test adding a file to a local package
- [ ] test adding a dependency to a local package
- [ ] add integration tests
- [ ] update doco
  - cmd docs
  - hugo docs
