### PR TITLE
fix: Warning missing `lexical-binding` cookie in Eask-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * fix(install): Package installed calculation (a479d5355dfc832286288b790338652e174d606d)
 * fix(install-file): Get correct install package name (#318)
 * feat: Add `:try` for `depends-on` DSL (#319)
+* fix: Warning missing `lexical-binding` cookie in Eask-file (#320)
 
 ## 0.11.x
 > Released Apr 03, 2025

--- a/Easkfile
+++ b/Easkfile
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "cli"
          "0.11.2"
          "A set of command-line tools to build Emacs packages")

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -112,6 +112,13 @@ If nil, never time out."
                  (const  :tag "Never time out" nil))
   :group 'eask)
 
+;; This is used to avoid the error:
+;;
+;;   Ignoring unknown mode `eask-mode'.
+;;
+(unless (fboundp 'eask-mode)
+  (define-derived-mode eask-mode emacs-lisp-mode "Eask"))
+
 ;;
 ;;; Execution
 

--- a/lisp/core/init.el
+++ b/lisp/core/init.el
@@ -76,7 +76,9 @@ Press ^C at any time to quit.")
                          (split-string keywords "[ \t\n]+" t "[ ]+")))
              (keywords (mapconcat (lambda (s) (format "%S" s)) keywords " "))
              (content (format
-                       "(package \"%s\"
+                       ";; -*- mode: eask; lexical-binding: t -*-
+
+(package \"%s\"
          \"%s\"
          \"%s\")
 

--- a/lisp/format/elisp-autofmt.el
+++ b/lisp/format/elisp-autofmt.el
@@ -45,7 +45,7 @@
       (kill-buffer))))
 
 (eask-start
-  (eask-command-check "28.1")
+  (eask-command-check "29.1")
 
   ;; Preparation
   (eask-archive-install-packages '("gnu" "melpa")

--- a/lisp/init/cask.el
+++ b/lisp/init/cask.el
@@ -146,7 +146,9 @@ Optional argument CONTENTS is used for nested directives.  e.g. development."
                         (keywords (split-string keywords "[, ]"))
                         (keywords (string-join keywords "\" \""))
                         (content (format
-                                  "(package \"%s\"
+                                  ";; -*- mode: eask; lexical-binding: t -*-
+
+(package \"%s\"
          \"%s\"
          \"%s\")
 

--- a/lisp/init/eldev.el
+++ b/lisp/init/eldev.el
@@ -50,7 +50,9 @@
                         (keywords (split-string keywords "[, ]"))
                         (keywords (string-join keywords "\" \""))
                         (content (format
-                                  "(package \"%s\"
+                                  ";; -*- mode: eask; lexical-binding: t -*-
+
+(package \"%s\"
          \"%s\"
          \"%s\")
 

--- a/lisp/init/keg.el
+++ b/lisp/init/keg.el
@@ -73,7 +73,9 @@ If no found the Keg file, returns nil."
                         (keywords (split-string keywords "[, ]"))
                         (keywords (string-join keywords "\" \""))
                         (content (format
-                                  "(package \"%s\"
+                                  ";; -*- mode: eask; lexical-binding: t -*-
+
+(package \"%s\"
          \"%s\"
          \"%s\")
 

--- a/lisp/init/source.el
+++ b/lisp/init/source.el
@@ -46,7 +46,9 @@
                           (keywords (string-join keywords "\" \""))
                           (reqs (package-desc-reqs pkg-desc))
                           (content (format
-                                    "(package \"%s\"
+                                    ";; -*- mode: eask; lexical-binding: t -*-
+
+(package \"%s\"
          \"%s\"
          %s)
 

--- a/test/color/Eask
+++ b/test/color/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "color"
          "0.0.1"
          "Test to print color on the terminal")

--- a/test/error/Eask
+++ b/test/error/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "error"
          "0.0.1"
          "Test (trigger) error on GitHub Actions")

--- a/test/fixtures/home/.emacs.d/Eask
+++ b/test/fixtures/home/.emacs.d/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package ".emacs.d"
          "0.0.1"
          "Minimal test configuration")

--- a/test/fixtures/home/Eask
+++ b/test/fixtures/home/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "home"
          "0.0.1"
          "Minimal test for global config")

--- a/test/fixtures/mini.pkg.1/Eask
+++ b/test/fixtures/mini.pkg.1/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "mini.pkg.1"
          "0.0.1"
          "Minimal test package")

--- a/test/fixtures/mini.pkg.2/Eask
+++ b/test/fixtures/mini.pkg.2/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "mini.pkg.2"
          "0.0.1"
          "Minimal test package")

--- a/test/jest/__snapshots__/analyze.test.js.snap
+++ b/test/jest/__snapshots__/analyze.test.js.snap
@@ -3,24 +3,24 @@
 exports[`analyze in ./dsl matches snapshot 1`] = `
 {
   "stderr": "
-~/Eask:7:18 Error: Multiple definition of \`package'
-~/Eask:10:55 Error: Multiple definition of \`website-url'
-~/Eask:12:16 Error: Multiple definition of \`keywords'
-~/Eask:15:15 Warning: Warning regarding duplicate author name, name
-~/Eask:18:17 Warning: Warning regarding duplicate license name, GPLv3
-~/Eask:21:29 Error: Multiple definition of \`package-file'
-~/Eask:23:35 Warning: Pkg-file seems to be missing \`check-pkg.el'
-~/Eask:24:35 Error: Multiple definition of \`package-descriptor'
-~/Eask:28:61 Error: Run-script with the same key name is not allowed: \`test\`
-~/Eask:31:13 Error: Multiple definition of source \`gnu'
-~/Eask:33:24 Error: Unknown package archive \`magic-archive'
-~/Eask:35:15 Error: Invalid archive name \`local'
-~/Eask:35:15 Error: Unknown package archive \`local'
-~/Eask:38:20 Error: Define dependencies with the same name \`emacs'
-~/Eask:41:19 Error: Define dependencies with the same name \`dash'
-~/Eask:42:27 Error: Define dependencies with the same name \`dash' with different version
-~/Eask:48:2 Error: Define dependencies with the same name \`f'
-~/Eask:48:2 Error: Define dependencies with the same name \`f' with different version
+~/Eask:9:18 Error: Multiple definition of \`package'
+~/Eask:12:55 Error: Multiple definition of \`website-url'
+~/Eask:14:16 Error: Multiple definition of \`keywords'
+~/Eask:17:15 Warning: Warning regarding duplicate author name, name
+~/Eask:20:17 Warning: Warning regarding duplicate license name, GPLv3
+~/Eask:23:29 Error: Multiple definition of \`package-file'
+~/Eask:25:35 Warning: Pkg-file seems to be missing \`check-pkg.el'
+~/Eask:26:35 Error: Multiple definition of \`package-descriptor'
+~/Eask:30:61 Error: Run-script with the same key name is not allowed: \`test\`
+~/Eask:33:13 Error: Multiple definition of source \`gnu'
+~/Eask:35:24 Error: Unknown package archive \`magic-archive'
+~/Eask:37:15 Error: Invalid archive name \`local'
+~/Eask:37:15 Error: Unknown package archive \`local'
+~/Eask:40:20 Error: Define dependencies with the same name \`emacs'
+~/Eask:43:19 Error: Define dependencies with the same name \`dash'
+~/Eask:44:27 Error: Define dependencies with the same name \`dash' with different version
+~/Eask:50:2 Error: Define dependencies with the same name \`f'
+~/Eask:50:2 Error: Define dependencies with the same name \`f' with different version
 ",
   "stdout": "",
 }

--- a/test/jest/buttercup/Eask
+++ b/test/jest/buttercup/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "buttercup"
          "0.0.1"
          "Test project for command `buttercup'")

--- a/test/jest/docker/Eask
+++ b/test/jest/docker/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "mini.pkg.1"
          "0.0.1"
          "Minimal test package")

--- a/test/jest/dsl/Eask
+++ b/test/jest/dsl/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432
 
 ;;

--- a/test/jest/ecukes/Eask
+++ b/test/jest/ecukes/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "ecukes"
          "0.0.1"
          "Test project for command `ecukes'")

--- a/test/jest/ert-runner/Eask
+++ b/test/jest/ert-runner/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "ert-runner"
          "0.0.1"
          "Test project for command `ert-runner'")

--- a/test/jest/ert/Eask
+++ b/test/jest/ert/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "ert"
          "0.0.1"
          "Test project for command `ert'")

--- a/test/jest/exec/Eask
+++ b/test/jest/exec/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "exec"
          "0.0.1"
          "Test project for command exec")

--- a/test/jest/global/Eask
+++ b/test/jest/global/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "home"
          "0.0.1"
          "Minimal test for global config")

--- a/test/jest/install/Eask
+++ b/test/jest/install/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "mini.pkg.1"
          "0.0.1"
          "Minimal test package")

--- a/test/jest/install/foo-mode/Eask
+++ b/test/jest/install/foo-mode/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "foo"
          "0.0.1"
          "")

--- a/test/jest/install/foo-no-pkg/Eask
+++ b/test/jest/install/foo-no-pkg/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "foo"
          "0.0.1"
          "")

--- a/test/jest/link/Eask
+++ b/test/jest/link/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "link"
          "1.0.0"
          "")

--- a/test/jest/link/link-fail/Eask
+++ b/test/jest/link/link-fail/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "mini.pkg.1"
          "0.0.1"
          "Minimal test package")

--- a/test/jest/link/link-to/Eask
+++ b/test/jest/link/link-to/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "link-to"
          "1.0.0"
          "simple package to link")

--- a/test/jest/local.test.js
+++ b/test/jest/local.test.js
@@ -230,7 +230,7 @@ describe("local", () => {
   describe("Formatting", () => {
     // installs elisp-autofmt
     it("format elisp-autofmt", async () => {
-      if ((await emacsVersion()) >= "28.1") {
+      if ((await emacsVersion()) >= "29.1") {
         await ctx.runEask("format elisp-autofmt");
       }
     });

--- a/test/jest/local/Eask
+++ b/test/jest/local/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "mini.pkg.1"
          "0.0.1"
          "Minimal test package")

--- a/test/jest/metadata/Eask
+++ b/test/jest/metadata/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432
 
 ;;

--- a/test/jest/options/Eask
+++ b/test/jest/options/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "options"
          "0.0.0"
          "Test all options flag")

--- a/test/jest/outdated-upgrade/Eask
+++ b/test/jest/outdated-upgrade/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "outdated-upgrade"
          "0.0.1"
          "Test project for command outdated and upgrade")

--- a/test/jest/search/Eask
+++ b/test/jest/search/Eask
@@ -1,3 +1,5 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
 (package "search"
          "0.0.1"
          "Test project for command `search'")


### PR DESCRIPTION
Attempt to fix warning:

```
eask compile
Warning (files): Missing ‘lexical-binding’ cookie in "~/work/company-fuzzy/company-fuzzy/Eask".
You can add one with ‘M-x elisp-enable-lexical-binding RET’.
See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’
for more information.
Compiling /home/runner/work/company-fuzzy/company-fuzzy/company-fuzzy.el... done ✓
```

Source: https://github.com/jcs-elpa/company-fuzzy/actions/runs/14594887284/job/40938348405#step:5:76