### PR TITLE
fix(core): Mark files before retrieving the package-dir-info

### DIFF
--- a/lisp/core/install-file.el
+++ b/lisp/core/install-file.el
@@ -51,6 +51,9 @@
       ;; Note `package-dir-info' doesn't work outside of dired mode!
       (let ((pkg-desc (with-temp-buffer
                         (dired path)
+                        ;; After Emacs 31, the function `package-dir-info'
+                        ;; will respect the marked files.
+                        (dired-mark-files-in-region (point-min) (point-max))
                         (ignore-errors (package-dir-info)))))
         (unless pkg-desc
           ;; `package-dir-info' will return nil if there is no `-pkg.el'


### PR DESCRIPTION
See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=78521#17.