### PR TITLE
Test exit status of compile command

### DIFF
--- a/test/jest/compile.test.js
+++ b/test/jest/compile.test.js
@@ -1,0 +1,51 @@
+const { TestContext } = require("./helpers");
+
+describe("compile", () => {
+  const ctx = new TestContext("./test/jest/compile");
+
+  afterAll(() => {
+    ctx.cleanUp();
+  });
+
+  describe("in an empty project", () => {
+    const ctxEmpty = new TestContext("./test/jest/empty");
+
+    it("should error on partial input", async () => {
+      await expect(ctxEmpty.runEask("compile")).rejects.toThrow();
+    });
+  });
+
+  describe("for compile/mock.el", () => {
+    it("should compile with a warning", async () => {
+      await ctx.runEask("compile mock.el");
+    });
+
+    it("should escalate warnings given --strict", async () => {
+      await expect(
+        ctx.runEask("compile --strict mock.el"),
+      ).rejects.toMatchObject({ code: 1 });
+    });
+  });
+
+  describe("for compile/fail.el", () => {
+    beforeEach(async () => {
+      await ctx.runEask("clean elc");
+    });
+
+    it("should error", async () => {
+      await expect(ctx.runEask("compile fail.el")).rejects.toMatchObject({
+        code: 1,
+      });
+    });
+
+    it("should compile mock.el given --allow-error", async () => {
+      await expect(
+        ctx.runEask("compile --allow-error fail.el mock.el"),
+      ).rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringContaining("1 file compiled, 1 skipped"),
+      });
+      expect(ctx.fileExists("./mock.elc"));
+    });
+  });
+});

--- a/test/jest/compile/Eask
+++ b/test/jest/compile/Eask
@@ -1,0 +1,2 @@
+;; -*- mode: eask; lexical-binding: t -*-
+(package "check" "0.0.1" "mock package")

--- a/test/jest/compile/fail.el
+++ b/test/jest/compile/fail.el
@@ -1,0 +1,3 @@
+;; -*- lexical-binding: t -*-
+;; this must fail to compile
+(fail "" (

--- a/test/jest/compile/mock.el
+++ b/test/jest/compile/mock.el
@@ -1,0 +1,5 @@
+;;;###autoload
+(defun my-ignore-fn ()
+  "Mock for testing"
+  (interactive)
+  (message "foo"))


### PR DESCRIPTION
Just adds unit tests for `eask compile`, no changes needed to `compile.el`.