### PR TITLE
Fix line containing format placeholders

### DIFF
--- a/lisp/lint/elsa.el
+++ b/lisp/lint/elsa.el
@@ -54,10 +54,10 @@
         (--each (reverse errors)
           (let ((line (string-trim (concat file ":" (elsa-message-format it)))))
             (cond ((string-match-p "[: ][Ee]rror:" line)
-                   (eask-error line))
+                   (eask-error "%s" line))
                   ((string-match-p "[: ][Ww]arning:" line)
-                   (eask-warn line))
-                  (t (eask-log line)))))
+                   (eask-warn "%s" line))
+                  (t (eask-log "%s" line)))))
       (eask-msg "No issues found"))))
 
 (eask-start


### PR DESCRIPTION
If the line reported by Elsa contains format string placeholders, the call to format in eask-error|warn will panic about missing arguments.

---

@scottrinh I noticed you already implemented a fix for the `Elsa` command, so I went ahead and opened the PR on your behalf. Hope that’s okay!