### PR TITLE
fix(lisp): Don't assume a list representation in `eask-current-time'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * fix: Ensure that `eask.js` has Unix line-endings ([#398](../../pull/398))
 * fix: Correctly parse operands from the command arguments ([#401](../../pull/401))
 * feat: Add new source `eine` ([`da75d6b`](../../commit/da75d6bf06fbf804f33262724dc17c3672a68e46))
+* fix(lisp): Don't assume a list representation in `eask-current-time` ([#432](../../pull/432))
 
 ## 0.12.x
 > Released Dec 02, 2025

--- a/lisp/_prepare.el
+++ b/lisp/_prepare.el
@@ -311,8 +311,12 @@ Argument BODY are forms for execution."
 
 ;; This is used to creating the directory recipe!
 (defun eask-current-time ()
-  "Return current time."
-  (let ((now (current-time))) (logior (ash (car now) 16) (cadr now))))
+  "Return current time, as a count of seconds since the epoch."
+  ;; Don't take `current-time' apart by hand: its representation depends on
+  ;; `current-time-list', which defaults to nil as of Emacs 32 and then yields
+  ;; a (TICKS . HZ) pair rather than a (HIGH LOW USEC PSEC) list.  `float-time'
+  ;; accepts either form and exists in every Emacs version Eask supports.
+  (floor (float-time)))
 
 (defun eask-seq-str-max (sequence)
   "Return max length in SEQUENCE of strings."


### PR DESCRIPTION
Fixes #431.

## Cause

`eask-current-time` rebuilt a seconds count out of the first two elements of `current-time`:

```elisp
(defun eask-current-time ()
  "Return current time."
  (let ((now (current-time))) (logior (ash (car now) 16) (cadr now))))
```

That assumes `current-time` returns a `(HIGH LOW USEC PSEC)` list. The representation is not guaranteed: it depends on `current-time-list`, which defaults to `nil` as of Emacs 32, so `current-time` returns a `(TICKS . HZ)` cons cell instead.

```elisp
;; Emacs 31 and earlier, or current-time-list = t
(current-time)  ;; => (27280 7881 699623 0)

;; Emacs 32 default
(current-time)  ;; => (1787829961699629000 . 1000000000)
```

With the cons cell, `cdr` is the plain integer `1000000000`, so `(cadr now)` evaluates `(car 1000000000)` and signals. That integer is `HZ`, the unit of the tick count, which is why the reported error reads:

```
Wrong type argument: listp, 1000000000
```

Because `eask-current-time` is used to build the directory recipe, `eask package` aborts before producing an artifact.

## Fix

Use `float-time`, which accepts either representation. `time-convert` would be the more direct API, but it requires Emacs 27.1 and `eask-required-emacs-version` is `26.1`, so `float-time` is used instead. `float-time` has existed since Emacs 21.

The result is unchanged for the list representation:

```
current-time-list = t:  legacy = 1787830323   float-time = 1787830323   identical
```

Integer seconds are represented exactly by a double up to roughly 9e15, so there is no precision concern for epoch timestamps.

I checked the rest of the tree: this was the only place a timestamp was decomposed by hand. The other `current-time` call sites in `lisp/_prepare.el` go through `time-subtract` and `float-time`, and the vendored `package-build` copies use `float-time` or `current-time-string`, all of which accept both representations.

## Verification

On GNU Emacs 32.0.50 (development build, 26 August 2026), with Eask 0.12.9 and this patch applied to the installed `lisp/_prepare.el`:

- Before: `eask package` fails with `Wrong type argument: listp, 1000000000`.
- After: `eask package` and `eask install` both succeed.

I verified it against a real project rather than a synthetic one, using `lsp-mode`, whose CI is currently blocked by this bug on all Unix Emacs snapshot jobs. With this patch, `lsp-mode` builds with no changes on its side, so the workaround it needs today (setting `current-time-list` back to `t` in its `Eask` file) can be removed once this is released.
